### PR TITLE
Multicolumn update

### DIFF
--- a/assets/css/components/Input_components.scss
+++ b/assets/css/components/Input_components.scss
@@ -96,6 +96,29 @@ textarea:focus, input:focus{
   }
 }
 
+.column-multi-select {
+  @extend .module-parameter;
+  position: relative; // so we can position button absolute
+  height: auto;
+
+  button {
+    cursor: pointer;
+    position: absolute;
+    right: 3.3rem;
+    bottom: 1.2rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    text-align: center;
+    border: 0;
+    background: transparent;
+    color: lighten($brand-orange, 6%);
+    &:hover {
+      color: $brand-orange
+    }
+  }
+
+}
+
 .single-line-text-field {
   @extend .module-parameter;
   position: relative; // so we can position button absolute

--- a/assets/css/components/Input_components.scss
+++ b/assets/css/components/Input_components.scss
@@ -96,7 +96,7 @@ textarea:focus, input:focus{
   }
 }
 
-.column-multi-select {
+.multi-select-input-group {
   @extend .module-parameter;
   position: relative; // so we can position button absolute
   height: auto;

--- a/assets/js/WfParameter.js
+++ b/assets/js/WfParameter.js
@@ -365,7 +365,7 @@ export default class WfParameter extends React.PureComponent {
   render() {
     const { id_name, name, type, visible_if, visible_if_not } = this.props.p.parameter_spec
 
-    // TODO: force display of 'colnames' for now since it will completely replace 'colselect' eventually
+    // TODO: delete the 'colnames' check. Force display of 'colnames' for now since it will completely replace 'colselect' eventually
     if (!this.props.p.visible && id_name !== 'colnames') {
       return null // nothing to see here
     }
@@ -520,27 +520,31 @@ export default class WfParameter extends React.PureComponent {
           </div>
         )
 
-      //TODO: Set all multi-column select modules to have type 'multicolumn' for 'colnames'
-      case 'multicolumn' && id_name === 'colnames':
+      // TODO: Set all multi-column select modules to have type 'multicolumn' for 'colnames', remove 'colselect' condition
+      // [2018-11-06] right now this code is never reached, but it will be when we
+      // finish cleaning up the multicolumn` parameter type.
+      case 'multicolumn':
         // There's no good reason why we read/write `colnames` instead of our own
         // id_name. But it'll be a chore to change it: we'll need to change all modules'
         // id_name to `colnames` so that pre-chore data will migrate over.
         //
         // (Then we'll have one more chore: select JSON instead of comma-separated strings)
-        return (
-          <div {...this.outerDivProps}>
-            <div className='t-d-gray content-3 label-margin'>{name}</div>
-            <ColumnSelector
-              name={id_name}
-              isReadOnly={this.props.isReadOnly}
-              initialValue={this.props.p.value}
-              value={this.props.value}
-              allColumns={this.props.inputColumns}
-              onSubmit={this.onSubmit}
-              onChange={this.onChange}
-            />
-          </div>
-        )
+        if (id_name !== 'colselect') {
+          return (
+            <div {...this.outerDivProps}>
+              <div className='t-d-gray content-3 label-margin'>{name}</div>
+              <ColumnSelector
+                name={id_name}
+                isReadOnly={this.props.isReadOnly}
+                initialValue={this.props.p.value}
+                value={this.props.value}
+                allColumns={this.props.inputColumns}
+                onSubmit={this.onSubmit}
+                onChange={this.onChange}
+              />
+            </div>
+          )
+        }
 
       case 'secret':
         return this.render_secret_parameter();

--- a/assets/js/WfParameter.js
+++ b/assets/js/WfParameter.js
@@ -365,7 +365,8 @@ export default class WfParameter extends React.PureComponent {
   render() {
     const { id_name, name, type, visible_if, visible_if_not } = this.props.p.parameter_spec
 
-    if (!this.props.p.visible) {
+    // TODO: force display of 'colnames' for now since it will completely replace 'colselect' eventually
+    if (!this.props.p.visible && id_name !== 'colnames') {
       return null // nothing to see here
     }
 
@@ -398,6 +399,25 @@ export default class WfParameter extends React.PureComponent {
                 rows={4}
                 defaultValue={this.props.p.value}
                 placeholder={this.props.p.parameter_spec.placeholder || ''}
+              />
+            </div>
+          )
+        }
+        // For now, let's render the 'colnames' parameter instead of 'colselect' so that we
+        // can keep the parameter's state in `WfModule`.
+        // TODO: convert the `colnames` type to 'multicolumn' and nix all other `multicolumn` parameters in every module
+        else if (id_name === 'colnames') {
+          return (
+            <div {...this.outerDivProps}>
+              <div className='t-d-gray content-3 label-margin'>{''}</div>
+              <ColumnSelector
+                name={id_name}
+                isReadOnly={this.props.isReadOnly}
+                initialValue={this.props.p.value}
+                value={this.props.value}
+                allColumns={this.props.inputColumns}
+                onSubmit={this.onSubmit}
+                onChange={this.onChange}
               />
             </div>
           )
@@ -500,7 +520,8 @@ export default class WfParameter extends React.PureComponent {
           </div>
         )
 
-      case 'multicolumn':
+      //TODO: Set all multi-column select modules to have type 'multicolumn' for 'colnames'
+      case 'multicolumn' && id_name === 'colnames':
         // There's no good reason why we read/write `colnames` instead of our own
         // id_name. But it'll be a chore to change it: we'll need to change all modules'
         // id_name to `colnames` so that pre-chore data will migrate over.
@@ -512,9 +533,11 @@ export default class WfParameter extends React.PureComponent {
             <ColumnSelector
               name={id_name}
               isReadOnly={this.props.isReadOnly}
-              value={this.props.getParamText('colnames')}
+              initialValue={this.props.p.value}
+              value={this.props.value}
               allColumns={this.props.inputColumns}
-              onChange={this.onColumnSelectorChange}
+              onSubmit={this.onSubmit}
+              onChange={this.onChange}
             />
           </div>
         )

--- a/assets/js/WfParameter.js
+++ b/assets/js/WfParameter.js
@@ -529,7 +529,7 @@ export default class WfParameter extends React.PureComponent {
         // id_name to `colnames` so that pre-chore data will migrate over.
         //
         // (Then we'll have one more chore: select JSON instead of comma-separated strings)
-        if (id_name !== 'colselect') {
+        if (id_name === 'colnames') {
           return (
             <div {...this.outerDivProps}>
               <div className='t-d-gray content-3 label-margin'>{name}</div>
@@ -544,6 +544,8 @@ export default class WfParameter extends React.PureComponent {
               />
             </div>
           )
+        } else {
+          return null
         }
 
       case 'secret':

--- a/assets/js/WfParameter.test.js
+++ b/assets/js/WfParameter.test.js
@@ -214,5 +214,28 @@ describe('WfParameter', () => {
     }, 'There is text');
     expect(wrapper.find('SingleLineTextField')).toHaveLength(0);
   });
+  it('Should render a "colnames" parameter that has type string', () => {
+    var wrapper = shallowParameter({
+      visible: true,
+      id: 123,
+      value: '',
+      parameter_spec: {
+        id_name: 'colnames',
+        type: 'string',
+      }
+    }, '');
+    expect(wrapper.find('ColumnSelector')).toHaveLength(1);
+  });
+  it('Should not render a "colselect" parameter that has type multicolumn', () => {
+    var wrapper = shallowParameter({
+      visible: true,
+      id: 123,
+      value: '',
+      parameter_spec: {
+        id_name: 'colselect',
+        type: 'multicolumn',
+      }
+    }, '');
+    expect(wrapper.find('ColumnSelector')).toHaveLength(0);
+  });
 });
-

--- a/assets/js/WfParameter.test.js
+++ b/assets/js/WfParameter.test.js
@@ -218,12 +218,12 @@ describe('WfParameter', () => {
     var wrapper = shallowParameter({
       visible: true,
       id: 123,
-      value: '',
+      value: 'A,B,C',
       parameter_spec: {
         id_name: 'colnames',
-        type: 'string',
+        type: 'string'
       }
-    }, '');
+    }, 'A,B,C');
     expect(wrapper.find('ColumnSelector')).toHaveLength(1);
   });
   it('Should not render a "colselect" parameter that has type multicolumn', () => {

--- a/assets/js/wfparameters/ColumnSelector.js
+++ b/assets/js/wfparameters/ColumnSelector.js
@@ -8,15 +8,13 @@ export default class ColumnSelector extends React.PureComponent {
     name: PropTypes.string.isRequired,
     isReadOnly: PropTypes.bool.isRequired,
     initialValue: PropTypes.string.isRequired,
-    onChange: PropTypes.func.isRequired,
-    onSubmit: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired, // onChange('A,B') => undefined
+    onSubmit: PropTypes.func.isRequired, // onSubmit() => undefined
     value: PropTypes.string.isRequired, // e.g., 'A,B'; may be '' but not null
     allColumns: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.string.isRequired
     }))
   }
-
-  buttonRef = React.createRef()
 
   get selectedColumns() {
     const { value } = this.props
@@ -67,7 +65,7 @@ export default class ColumnSelector extends React.PureComponent {
       }
     ))
     const maybeButton = initialValue === value ? null : (
-      <button title="submit" ref={this.buttonRef} onClick={this.props.onSubmit}>
+      <button title="submit" onClick={this.props.onSubmit}>
         <i className="icon-play" />
       </button>
     )
@@ -94,7 +92,7 @@ export default class ColumnSelector extends React.PureComponent {
             None
           </button>
         </div>
-        <div className="column-multi-select">
+        <div className="multi-select-input-group">
           <Select
             isMulti
             name='columns'

--- a/assets/js/wfparameters/ColumnSelector.js
+++ b/assets/js/wfparameters/ColumnSelector.js
@@ -7,12 +7,16 @@ export default class ColumnSelector extends React.PureComponent {
   static propTypes = {
     name: PropTypes.string.isRequired,
     isReadOnly: PropTypes.bool.isRequired,
+    initialValue: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
     value: PropTypes.string.isRequired, // e.g., 'A,B'; may be '' but not null
     allColumns: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.string.isRequired
-    })),
-    onChange: PropTypes.func.isRequired // onChange('A,B') => undefined
+    }))
   }
+
+  buttonRef = React.createRef()
 
   get selectedColumns() {
     const { value } = this.props
@@ -41,7 +45,7 @@ export default class ColumnSelector extends React.PureComponent {
   }
 
   render() {
-    const { allColumns, isReadOnly, name } = this.props
+    const { allColumns, isReadOnly, name, initialValue, value } = this.props
 
     if (allColumns === null) {
       return (
@@ -62,7 +66,11 @@ export default class ColumnSelector extends React.PureComponent {
         value: column
       }
     ))
-
+    const maybeButton = initialValue === value ? null : (
+      <button title="submit" ref={this.buttonRef} onClick={this.props.onSubmit}>
+        <i className="icon-play" />
+      </button>
+    )
     return (
       // The name attributes in the buttons are used for selection in tests. Do not change them.
       <div>
@@ -73,7 +81,7 @@ export default class ColumnSelector extends React.PureComponent {
             title='Select All'
             onClick={this.onClickSelectAll}
             className='mc-select-all content-4 t-d-gray'
-            >
+          >
             All
           </button>
           <button
@@ -82,22 +90,25 @@ export default class ColumnSelector extends React.PureComponent {
             title='Select None'
             onClick={this.onClickSelectNone}
             className='mc-select-none content-4 t-d-gray'
-            >
+          >
             None
           </button>
         </div>
-        <Select
-          isMulti
-          name='columns'
-          options={columnOptions}
-          menuPortalTarget={document.body}
-          className='react-select'
-          classNamePrefix='react-select'
-          onChange={this.onSelectColumn}
-          value={selectedColumns}
-          isClearable={false}
-          placeholder='Select columns'
-        />
+        <div className="column-multi-select">
+          <Select
+            isMulti
+            name='columns'
+            options={columnOptions}
+            menuPortalTarget={document.body}
+            className='react-select'
+            classNamePrefix='react-select'
+            onChange={this.onSelectColumn}
+            value={selectedColumns}
+            isClearable={false}
+            placeholder='Select columns'
+          />
+          {maybeButton}
+        </div>
       </div>
     )
   }

--- a/assets/js/wfparameters/ColumnSelector.test.js
+++ b/assets/js/wfparameters/ColumnSelector.test.js
@@ -52,11 +52,13 @@ describe('ColumnSelector', () => {
     it('should sort the selected columns in order', () => {
       const w = mount(
         <ColumnSelector
+          onChange={jest.fn()}
+          onSubmit={jest.fn()}
           name='column'
           isReadOnly={false}
           value='C,A,D'
+          initialValue={'C,A,D'}
           allColumns={[{name: 'D'}, {name: 'A'}, {name: 'C'}, {name: 'B'}]}
-          onChange={jest.fn()}
         />
       )
       const expected = [
@@ -75,6 +77,10 @@ describe('ColumnSelector', () => {
     it('should show submit button when new column added', () => {
       const w = mount(
         <ColumnSelector
+          onChange={jest.fn()}
+          onSubmit={jest.fn()}
+          name='column'
+          isReadOnly={false}
           initialValue={'A,B,C'}
           value='A,C'
           allColumns={[{name: 'D'}, {name: 'A'}, {name: 'C'}, {name: 'B'}]}
@@ -98,6 +104,8 @@ describe('ColumnSelector', () => {
           allColumns={[{name: 'D'}, {name: 'A'}, {name: 'C'}, {name: 'B'}]}
           onChange={jest.fn()}
           onSubmit={jest.fn()}
+          name='column'
+          isReadOnly={false}
         />
       )
       w.find('button[title="submit"]').simulate('click')

--- a/assets/js/wfparameters/ColumnSelector.test.js
+++ b/assets/js/wfparameters/ColumnSelector.test.js
@@ -5,11 +5,13 @@ import { mount } from 'enzyme'
 describe('ColumnSelector', () => {
   const wrapper = (extraProps={}) => mount(
     <ColumnSelector
+      onChange={jest.fn()}
+      onSubmit={jest.fn()}
       name='column'
       isReadOnly={false}
+      initialValue={'A,C'}
       value='A,C'
       allColumns={[{name: 'A'}, {name: 'B'}, {name: 'C'}, {name: 'D'}]}
-      onChange={jest.fn()}
       {...extraProps}
     />
   )
@@ -63,6 +65,44 @@ describe('ColumnSelector', () => {
         {label: 'C', value: 'C'}
       ]
       expect(w.find('Select[name="columns"]').prop('value')).toEqual(expected)
+    })
+
+    it('should not show a submit button when value is unchanged', () => {
+      const w = wrapper()
+      expect(w.find('button.submit')).toHaveLength(0)
+    })
+
+    it('should show submit button when new column added', () => {
+      const w = mount(
+        <ColumnSelector
+          initialValue={'A,B,C'}
+          value='A,C'
+          allColumns={[{name: 'D'}, {name: 'A'}, {name: 'C'}, {name: 'B'}]}
+        />
+      )
+      expect(w.find('button[title="submit"]')).toHaveLength(1)
+    })
+
+    it('should call onChange but not onSubmit when columns are added', () => {
+      const w = wrapper()
+      w.find('button[title="Select All"]').simulate('click')
+      expect(w.prop('onChange')).toHaveBeenCalledWith('A,B,C,D')
+      expect(w.prop('onSubmit')).not.toHaveBeenCalled()
+    })
+
+    it('should call onSubmit when columns added and button pressed', () => {
+      const w = mount(
+        <ColumnSelector
+          initialValue={'A,B,C'}
+          value='A,C'
+          allColumns={[{name: 'D'}, {name: 'A'}, {name: 'C'}, {name: 'B'}]}
+          onChange={jest.fn()}
+          onSubmit={jest.fn()}
+        />
+      )
+      w.find('button[title="submit"]').simulate('click')
+      expect(w.prop('onChange')).not.toHaveBeenCalled()
+      expect(w.prop('onSubmit')).toHaveBeenCalled()
     })
   })
 })

--- a/integrationtests/lessons/test_clean_and_standardize.py
+++ b/integrationtests/lessons/test_clean_and_standardize.py
@@ -73,6 +73,7 @@ class TestLesson(LessonTest):
         b.click_whatever('.react-select__option', text='MetroArea', wait=True)
         b.click_whatever('.react-select__indicator', wait=True)
         b.click_whatever('.react-select__option', text='Population', wait=True)
+        b.click_button('submit')
 
         self.expect_highlight_next()
         self.click_next()

--- a/server/modules/selectcolumns.json
+++ b/server/modules/selectcolumns.json
@@ -11,11 +11,18 @@
       "id_name": "colselect",
       "type": "multicolumn",
       "ui-only": true,
+      "visible": false,
       "visible_if": {
         "id_name": "select_range",
         "value": false,
         "invert": false
       }
+    },
+    {
+      "name": "Column Names",
+      "id_name": "colnames",
+      "type": "string",
+      "visible": true
     },
     {
       "name": "Column numbers",
@@ -41,12 +48,6 @@
       "type" : "radio",
       "radio_items" : "Delete|Keep",
       "default": "1"
-    },
-    {
-      "name": "Column Names",
-      "id_name": "colnames",
-      "type": "string",
-      "visible": false
     }
   ]
 }


### PR DESCRIPTION
First pass. Render `colnames` instead of `colselect` and update Select Columns modules to match layout placement.