### PR TITLE
Don't _always_ render after fetch

### DIFF
--- a/server/models/Delta.py
+++ b/server/models/Delta.py
@@ -141,7 +141,9 @@ class Delta(PolymorphicModel):
         return data
 
     async def schedule_execute(self) -> None:
-        await rabbitmq.queue_render(self.workflow)
+        """Tell renderers to render the new workflow."""
+        await rabbitmq.queue_render(self.workflow.id,
+                                    self.workflow.last_delta_id)
 
     @classmethod
     async def create(cls, *, workflow, **kwargs):
@@ -165,7 +167,7 @@ class Delta(PolymorphicModel):
 
         Example:
 
-            delta = await Delta.create_impl(ChangeWfModuleNotesCommand,
+            delta = await ChangeWfModuleNotesCommand.create_impl(
                 workflow=wf_module.workflow,
                 # ... other kwargs
             )

--- a/server/models/commands/ChangeDataVersionCommand.py
+++ b/server/models/commands/ChangeDataVersionCommand.py
@@ -1,11 +1,21 @@
+from channels.db import database_sync_to_async
 from django.db import models
 from server.models import Delta, WfModule
+from server import websockets
 from .util import ChangesWfModuleOutputs
 
 
+@database_sync_to_async
+def _workflow_has_notifications(workflow):
+    """Detect whether a workflow sends email on changes."""
+    return workflow.wf_modules.filter(notifications=True).exists()
+
+
 class ChangeDataVersionCommand(Delta, ChangesWfModuleOutputs):
-    wf_module = models.ForeignKey(WfModule, null=True, default=None, blank=True, on_delete=models.SET_DEFAULT)
-    old_version = models.DateTimeField('old_version', null=True)    # may not have had a previous version
+    wf_module = models.ForeignKey(WfModule, null=True, default=None,
+                                  blank=True, on_delete=models.SET_DEFAULT)
+    # may not have had a previous version
+    old_version = models.DateTimeField('old_version', null=True)
     new_version = models.DateTimeField('new_version')
     dependent_wf_module_last_delta_ids = \
         ChangesWfModuleOutputs.dependent_wf_module_last_delta_ids
@@ -20,17 +30,66 @@ class ChangeDataVersionCommand(Delta, ChangesWfModuleOutputs):
         self.wf_module.save()
         self.wf_module.set_fetched_data_version(self.old_version)
 
+    async def schedule_execute(self) -> None:
+        """
+        Tell renderers to render the new workflow, _maybe_.
+
+        ChangeDataVersionCommand is often created from a fetch, and fetches
+        are often invoked by cron. These tend to be our most resource-heavy
+        operations: e.g., Twitter-accumulate with 1M records. So let's use lazy
+        rendering.
+
+        From our point of view:
+
+            * If self.workflow has notifications, render.
+            * If anybody is viewing self.workflow right now, render.
+
+        Of course, it's impossible for us to know whether anybody is viewing
+        self.workflow. So we _broadcast_ to them and ask _them_ to request a
+        render if they're listening. This gives N render requests (one per
+        Websockets communicator) instead of 1, but we don't mind because
+        spurious render requests are no-ops.
+
+        From the user's point of view:
+
+            * If I'm viewing self.workflow, changing data versions causes a
+              render. (There isn't even any HTTP traffic: the communicator
+              does the work.)
+            * Otherwise, the next time I browse to the page, the page-load
+              will request a render.
+
+        Assumptions:
+
+            * Websockets communicators queue a render when we ask them.
+            * The Django page-load view queues a render when needed.
+        """
+        if await _workflow_has_notifications(self.workflow):
+            await super().schedule_execute()
+        else:
+            await websockets.queue_render_if_listening(
+                self.workflow.id,
+                self.workflow.last_delta_id
+            )
+
+    @classmethod
+    def amend_create_kwargs(cls, *, wf_module, **kwargs):
+        return {
+            **kwargs,
+            'wf_module': wf_module,
+            'old_version': wf_module.get_fetched_data_version(),
+        }
+
     @classmethod
     async def create(cls, wf_module, version):
-        delta = await cls.create_impl(
+        return await cls.create_impl(
+            workflow=wf_module.workflow,
             wf_module=wf_module,
-            new_version=version,
-            old_version=wf_module.get_fetched_data_version(),
-            workflow=wf_module.workflow
+            new_version=version
         )
-
-        return delta
 
     @property
     def command_description(self):
-        return f'Change {self.wf_module.get_module_name()} data version to {self.version}'
+        return (
+            f'Change {self.wf_module.get_module_name()} data version to '
+            f'{self.version}'
+        )

--- a/server/rabbitmq.py
+++ b/server/rabbitmq.py
@@ -102,14 +102,14 @@ async def get_connection(loop=None):
             return _loop_to_connection[loop]
 
 
-async def queue_render(workflow):
+async def queue_render(workflow_id: int, delta_id: int):
     """
     Queue render in RabbitMQ.
 
     Spurious renders are fine: these messages are tiny.
     """
     connection = await get_connection()
-    await connection.queue_render(workflow.id, workflow.last_delta_id)
+    await connection.queue_render(workflow_id, delta_id)
 
 
 async def queue_fetch(wf_module):

--- a/server/views/workflows.py
+++ b/server/views/workflows.py
@@ -194,7 +194,8 @@ def render_workflow(request: HttpRequest, workflow: Workflow):
             #
             # Normally this is a race and this render is spurious. TODO prevent
             # two workers from rendering the same workflow at the same time.
-            async_to_sync(rabbitmq.queue_render)(workflow)
+            async_to_sync(rabbitmq.queue_render)(workflow.id,
+                                                 workflow.last_delta_id)
 
         return TemplateResponse(request, 'workflow.html',
                                 {'initState': init_state})


### PR DESCRIPTION
This should help with slow cron jobs that nobody checks. Now, we only
render after fetch if we might send an email or if a user has that
workflow open.