### PR TITLE
Add Hext as Workbench pipenv dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -37,6 +37,7 @@ channels-rabbitmq = "==0.0.3"
 asyncpg = "*"
 oauthlib = "*"
 "fb-re2" = "*"
+hext = "==0.2.0"
 
 [dev-packages]
 watchdog = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5748d69ec771e22f0f1cd2a50cb96f08d529947d5f1e3fc44929157af8c61f36"
+            "sha256": "e87f33eb8dbd60c53af619ef2a651f8eea847960b3d01ffbf593871236129fdb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -307,6 +307,18 @@
             ],
             "index": "pypi",
             "version": "==2.1.3"
+        },
+        "hext": {
+            "hashes": [
+                "sha256:3aeccee6fe496211bbf725832e22368ad87d0a1afb233a695f825a81ad3a1923",
+                "sha256:4df0f4fed63199fcb436186a2f16bb5e2f8a9dbf4e0eb8cb07d444992a463052",
+                "sha256:8d895b39e3b5569f5bd02fe1444bffbd8036d156ed16006cdecfbfbdde1ccfe5",
+                "sha256:a9edf2f5b034178e2b2127724c35954446669cd7e1319cdde568d1d9c7f2d80a",
+                "sha256:cf81be7f04e816a05d9384ab971ef9447dfc478f47cf5428859c34fe1d4f4fde",
+                "sha256:f282b7a0e518d3646bcde8eeb7f0164c668a2ef5580611b2b62f98b7a05570b9"
+            ],
+            "index": "pypi",
+            "version": "==0.2.0"
         },
         "html5lib": {
             "hashes": [
@@ -818,17 +830,19 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:2556b779125621b311844a072e0ed367e8409a18fa12cbd68eb1258d187820f9",
-                "sha256:4aec0769f1799a9d4496827292c02a7b1f75c0bab56ab2b60dd94ebb57cbd5ee",
-                "sha256:55369d95afaacf2fa6b49c84d18b51f1704a6560c432a0f9a1aeb23f7b971308",
-                "sha256:6c098b85442c8fe3303e708bbb775afd0f6b29f77612e8892627bcab4b939357",
-                "sha256:9182cd6f93412d32e009020a44d6d170d2093646464a88aeec2aef50592f8c78",
-                "sha256:c8cbc21bbfa1dd7d5386d48cc814fe3d35b80f60299cdde9279046f399c3b0d8",
-                "sha256:db6f70a4b09cde813a4807843abaaa60f3b15fb4a2a06f9ae9c311472662daa1",
-                "sha256:f17495e6fe3d377e3faac68121caef6f974fcb9e046bc075bcff40d8e5cc69a4",
-                "sha256:f85900b9cca0c67767bb61b2b9bd53208aaa7373dae633dbe25d179b4bf38aa7"
+                "sha256:024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9",
+                "sha256:2f3010703295fbe1aec51023740871e64bb9664c789cba5a6bdf404e93f7568f",
+                "sha256:3890ab952d508523ef4881457c4099056546593fa05e93da84c7250516e632eb",
+                "sha256:3e2724eb9af5dc41648e5bb304fcf4891adc33258c6e14e2a7414ea32541e320",
+                "sha256:5badb97dd0abf26623a9982cd448ff12cb39b8e4c94032ccdedf22ce01a64842",
+                "sha256:73f447d11b530d860ca1e6b582f947688286ad16ca42256413083d13f260b7a0",
+                "sha256:7ab825726f2940c16d92aaec7d204cfc34ac26c0040da727cf8ba87255a33829",
+                "sha256:b25de84a8c20540531526dfbb0e2d2b648c13fd5dd126728c496d7c3fea33310",
+                "sha256:c6e341f5a6562af74ba55205dbd56d248daf1b5748ec48a0200ba227bb9e33f4",
+                "sha256:c9bb7c249c4432cd47e75af3864bc02d26c9594f49c82e2a28624417f0ae63b8",
+                "sha256:e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1"
             ],
-            "version": "==1.2.6"
+            "version": "==1.3.0"
         },
         "zope.interface": {
             "hashes": [


### PR DESCRIPTION
This PR adds Hext version 0.2.0 as a Workbench dependency. This is all that's required to get the [extractor module](https://github.com/brandonrobertz/autoscrape-extractor-workbench) working.