### PR TITLE
Add "set-params" iframe postMessage handler

### DIFF
--- a/assets/js/OutputIframe.js
+++ b/assets/js/OutputIframe.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types'
 import Modal from 'reactstrap/lib/Modal'
 import ModalHeader from 'reactstrap/lib/ModalHeader'
 import ModalBody from 'reactstrap/lib/ModalBody'
-import { setWorkflowPublicAction } from './workflow-reducer'
+import {
+  setWorkflowPublicAction,
+  setWfModuleParamsAction
+} from './workflow-reducer'
 import { connect } from 'react-redux'
 import { escapeHtml } from './utils'
 
@@ -66,6 +69,9 @@ export class OutputIframe extends React.PureComponent {
       switch (data.type) {
         case 'resize':
           this.setState({ heightFromIframe: data.height })
+          break
+        case 'set-params':
+          this.props.setWfModuleParams(data.wfModuleId, data.params)
           break
         default:
           console.error('Unhandled message from iframe', data)
@@ -176,6 +182,9 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     setWorkflowPublic: () => {
       dispatch(setWorkflowPublicAction(ownProps.workflowId, true))
+    },
+    setWfModuleParams: (wfModuleId, params) => {
+      dispatch(setWfModuleParamsAction(wfModuleId, params))
     }
   }
 }


### PR DESCRIPTION
This adds a "set-params" postMessage handler that allows a HTML/JS module to modify its parameters. It can be used similarly to the 'resize' message, for example:

```
window.parent.postMessage({
  from: 'outputIframe',
  type: 'set-params',
  params: {
    param_key: "param_value"
  },
  wfModuleId: ...,
}, window.location.origin)
```

Example of its use in my data extractor module's latest commit: https://github.com/brandonrobertz/autoscrape-extractor-workbench/commit/84588964186e4e0fb365c08bc3d4ddc88fef40cf