### PR TITLE
Use true ICU in python

### DIFF
--- a/cjworkbench/i18n/trans.py
+++ b/cjworkbench/i18n/trans.py
@@ -20,7 +20,7 @@ def _get_translations(locale):
     """
     if locale in _translators:
         return _translators[locale]
-    _translators[locale] = MessageTranslator(locale)
+    _translators[locale] = MessageTranslator.for_application_messages(locale)
     return _translators[locale]
 
 
@@ -86,18 +86,22 @@ def restore_tags(message, tag_mapping):
 
 
 class MessageTranslator:
-    """Load the message catalogs for a given locale and provide helper methods for message translation.
+    """Hold a message catalog for a given locale and provide helper methods for message localization with ICU.
     It uses plaintext messages with variables in `{var}` placeholders, e.g. in `"Hello {name}"`, `name` is a variable.
     
     Essentially, it is a wrapper for the combination of 
-      - Babel (for loading PO files)
-      - variable substitution
+      - Babel (for reading messages of PO files)
+      - variable substitution with ICU
       - our HTML placeholder construct.
     """
 
-    def __init__(self, locale_id):
+    def __init__(self, locale_id, catalog):
         self.icu_locale = Locale.createFromName(locale_id)
-        self.catalog = load_catalog(locale_id)
+        self.catalog = catalog
+
+    @classmethod
+    def for_application_messages(cls, locale_id: str):
+        return cls(locale_id, load_catalog(locale_id))
 
     def trans(self, message_id, default=None, context=None, parameters={}):
         """Find the message corresponding to the given ID in the catalog and format it according to the given parameters.

--- a/cjworkbench/i18n/trans.py
+++ b/cjworkbench/i18n/trans.py
@@ -46,37 +46,20 @@ def trans(message_id, *, default, context=None, parameters={}):
     For code parsing reasons, respect the following order when passing keyword arguments:
         `message_id` and then `default` and then `context` and then everything else
     """
-    return do_trans(
-        get_language(),
-        message_id,
-        default=default,
-        context=context,
-        parameters=parameters,
-    )
-
-
-def do_trans(locale_id, message_id, *, default, context=None, parameters={}):
-    """Translate the given message ID to the given locale
-    
-    HTML is not escaped.
-    
-    For code parsing reasons, respect the following order when passing keyword arguments:
-        `message_id` and then `default` and then `context` and then everything else
-    """
-    return _get_translations(locale_id).trans(
+    return _get_translations(get_language()).trans(
         message_id, default=default, context=context, parameters=parameters
     )
 
 
-def trans_html(locale, message_id, *, default, context=None, parameters={}, tags={}):
-    """Translate the given message ID to the current locale
+def trans_html(locale_id, message_id, *, default, context=None, parameters={}, tags={}):
+    """Translate the given message ID to the given locale
     
     HTML is escaped in the message, as well as in parameters and tag attributes.
     
     For code parsing reasons, respect the following order when passing keyword arguments:
         `message_id` and then `default` and then `context` and then everything else
     """
-    return _get_translations(locale).trans_html(
+    return _get_translations(locale_id).trans_html(
         message_id, default=default, context=context, parameters=parameters, tags=tags
     )
 

--- a/cjworkbench/tests/i18n/test_trans.py
+++ b/cjworkbench/tests/i18n/test_trans.py
@@ -1,10 +1,5 @@
 from django.test import SimpleTestCase
-from cjworkbench.i18n.trans import (
-    trans_html,
-    trans,
-    MessageTranslator,
-    InvalidICUParameters,
-)
+from cjworkbench.i18n.trans import trans_html, trans, MessageTranslator
 from cjworkbench.i18n import default_locale
 
 
@@ -27,22 +22,31 @@ class TransTest(SimpleTestCase):
             "Hello you there {c}!",
         )
 
-    # Tests that a programmer will get an exception when including a numeric variable in the message
+    # Tests that a programmer can include a numeric variable in the message
     def test_format_invalid_default(self):
-        with self.assertRaises(InvalidICUParameters):
+        self.assertEqual(
             trans(
                 mock_message_id,
                 default="Hello {a} {0} {b}",
                 parameters={"a": "you", "0": "!", "b": "2"},
             ),
+            "Hello you ! 2",
+        )
 
     # Tests that a translator can't break our system by including a numeric variable in the message
     def test_format_invalid_message(self):
-        self.assertEqual(
+        self.assertTrue(
             MessageTranslator(default_locale)._process_simple_message(
                 "Hello {a} {0} {b}", "Hello {a} {b}", parameters={"a": "you", "b": "!"}
-            ),
-            "Hello you !",
+            )
+        )
+
+    # Tests that a translator can't break our system by adding or removing variables in the message
+    def test_format_translator_parameters(self):
+        self.assertTrue(
+            MessageTranslator(default_locale)._process_simple_message(
+                "Hello {a} {c}", "Hello {a} {b}", parameters={"a": "you", "b": "!"}
+            )
         )
 
     # Tests that HTML is not escaped
@@ -54,6 +58,46 @@ class TransTest(SimpleTestCase):
                 parameters={"param_b": "> there"},
             ),
             'Hello <a href="/you?a=n&b=e">you > > there</a> my & friend',
+        )
+
+    # Tests that plurals, selects and nested messages are fully supported
+    def test_icu_support(self):
+        message = (
+            "Hello {a}, you have {g, select,"
+            "   male {{n, plural,"
+            "       =0 {no boys} one {# little boy} other {# little boys}"
+            "   }}"
+            "   female {{n, plural,"
+            "       =0 {no girls} one {# little girl} other {# little girls}"
+            "   }}"
+            "   other {{n, plural,"
+            "       =0 {no children} one {# little child} other {# little children}"
+            "   }}"
+            "}"
+        )
+        self.assertEqual(
+            trans(
+                mock_message_id,
+                default=message,
+                parameters={"a": "there", "g": "male", "n": 17},
+            ),
+            "Hello there, you have 17 little boys",
+        )
+        self.assertEqual(
+            trans(
+                mock_message_id,
+                default=message,
+                parameters={"a": "there", "g": "female", "n": 18},
+            ),
+            "Hello there, you have 18 little girls",
+        )
+        self.assertEqual(
+            trans(
+                mock_message_id,
+                default=message,
+                parameters={"a": "there", "g": "other", "n": 0},
+            ),
+            "Hello there, you have no children",
         )
 
 
@@ -72,23 +116,32 @@ class TransHtmlTest(SimpleTestCase):
             "Hello you there {c}!",
         )
 
-    # Tests that a programmer will get an exception when including a numeric variable in the message
+    # Tests that a programmer can include a numeric variable in the message
     def test_format_invalid_default(self):
-        with self.assertRaises(InvalidICUParameters):
+        self.assertEqual(
             trans_html(
                 default_locale,
                 mock_message_id,
                 default="Hello {a} {0} {b}",
                 parameters={"a": "you", "0": "!", "b": "2"},
             ),
+            "Hello you ! 2",
+        )
 
     # Tests that a translator can't break our system by including a numeric variable in the message
     def test_format_invalid_message(self):
-        self.assertEqual(
+        self.assertTrue(
             MessageTranslator(default_locale)._process_html_message(
                 "Hello {a} {0} {b}", "Hello {a} {b}", parameters={"a": "you", "b": "!"}
-            ),
-            "Hello you !",
+            )
+        )
+
+    # Tests that a translator can't break our system by adding or removing variables in the message
+    def test_format_translator_parameters(self):
+        self.assertTrue(
+            MessageTranslator(default_locale)._process_html_message(
+                "Hello {a} {c}", "Hello {a} {b}", parameters={"a": "you", "b": "!"}
+            )
         )
 
     # Tests that tags in messages are replaced correctly.
@@ -192,12 +245,13 @@ class TransHtmlTest(SimpleTestCase):
     # 3) Special characters, except for the ones of valid tags, are escaped
     # 4) Nested tags are not tolerated
     # 5) `arg_XX` arguments are replaced and escaped correctly
+    # 6) The same tag can appear multiple times
     def test_trans_tag_placeholders(self):
         self.assertEqual(
             trans_html(
                 default_locale,
                 mock_message_id,
-                default='<span0 class="nope">Hello {first}</span0><span1></span1> {second} <a0>{a}<b></b></a0> < <a1>there<</a1>!<br /><script type="text/javascript" src="mybadscript.js"></script>',
+                default='<span0 class="nope">Hello {first}</span0><span1></span1> <span0>{second}</span0> <a0>{a}<b></b></a0> < <a1>there<</a1>!<br /><script type="text/javascript" src="mybadscript.js"></script>',
                 parameters={"a": "you", "first": "hello", "second": "&"},
                 tags={
                     "a0": {"tag": "a", "attrs": {"href": "/you"}},
@@ -208,5 +262,51 @@ class TransHtmlTest(SimpleTestCase):
                     "span0": {"tag": "span", "attrs": {"id": "hi"}},
                 },
             ),
-            '<span id="hi">Hello hello</span> &amp; <a href="/you">you</a> &lt; <a class="red big" href="/there?a=b&amp;c=d">there&lt;</a>!',
+            '<span id="hi">Hello hello</span> <span id="hi">&amp;</span> <a href="/you">you</a> &lt; <a class="red big" href="/there?a=b&amp;c=d">there&lt;</a>!',
+        )
+
+    # Tests that plurals, selects and nested messages are fully supported
+    def test_icu_support(self):
+        message = (
+            "Hello {a}, you have {g, select,"
+            "   male {{n, plural,"
+            "       =0 {<em0>no</em0> boys} one {# little boy} other {# little boys}"
+            "   }}"
+            "   female {{n, plural,"
+            "       =0 {<em0>no</em0> girls} one {# little girl} other {# little girls}"
+            "   }}"
+            "   other {{n, plural,"
+            "       =0 {<em0>no</em0> children} one {# little child} other {# little children}"
+            "   }}"
+            "}"
+        )
+        self.assertEqual(
+            trans_html(
+                default_locale,
+                mock_message_id,
+                default=message,
+                parameters={"a": "there", "g": "male", "n": 17},
+                tags={"em0": {"tag": "em", "attrs": {}}},
+            ),
+            "Hello there, you have 17 little boys",
+        )
+        self.assertEqual(
+            trans_html(
+                default_locale,
+                mock_message_id,
+                default=message,
+                parameters={"a": "there", "g": "female", "n": 18},
+                tags={"em0": {"tag": "em", "attrs": {}}},
+            ),
+            "Hello there, you have 18 little girls",
+        )
+        self.assertEqual(
+            trans_html(
+                default_locale,
+                mock_message_id,
+                default=message,
+                parameters={"a": "there", "g": "other", "n": 0},
+                tags={"em0": {"tag": "em", "attrs": {}}},
+            ),
+            "Hello there, you have <em>no</em> children",
         )

--- a/cjworkbench/tests/i18n/test_trans.py
+++ b/cjworkbench/tests/i18n/test_trans.py
@@ -65,13 +65,13 @@ class TransTest(SimpleTestCase):
         message = (
             "Hello {a}, you have {g, select,"
             "   male {{n, plural,"
-            "       =0 {no boys} one {# little boy} other {# little boys}"
+            "       =0 {no boys} one {# boy} other {# boys}"
             "   }}"
             "   female {{n, plural,"
-            "       =0 {no girls} one {# little girl} other {# little girls}"
+            "       =0 {no girls} one {# girl} other {# girls}"
             "   }}"
             "   other {{n, plural,"
-            "       =0 {no children} one {# little child} other {# little children}"
+            "       =0 {no children} one {# child} other {# children}"
             "   }}"
             "}"
         )
@@ -81,7 +81,7 @@ class TransTest(SimpleTestCase):
                 default=message,
                 parameters={"a": "there", "g": "male", "n": 17},
             ),
-            "Hello there, you have 17 little boys",
+            "Hello there, you have 17 boys",
         )
         self.assertEqual(
             trans(
@@ -89,7 +89,7 @@ class TransTest(SimpleTestCase):
                 default=message,
                 parameters={"a": "there", "g": "female", "n": 18},
             ),
-            "Hello there, you have 18 little girls",
+            "Hello there, you have 18 girls",
         )
         self.assertEqual(
             trans(
@@ -270,13 +270,13 @@ class TransHtmlTest(SimpleTestCase):
         message = (
             "Hello {a}, you have {g, select,"
             "   male {{n, plural,"
-            "       =0 {<em0>no</em0> boys} one {# little boy} other {# little boys}"
+            "       =0 {<em0>no</em0> boys} one {# boy} other {# boys}"
             "   }}"
             "   female {{n, plural,"
-            "       =0 {<em0>no</em0> girls} one {# little girl} other {# little girls}"
+            "       =0 {<em0>no</em0> girls} one {# girl} other {# girls}"
             "   }}"
             "   other {{n, plural,"
-            "       =0 {<em0>no</em0> children} one {# little child} other {# little children}"
+            "       =0 {<em0>no</em0> children} one {# child} other {# children}"
             "   }}"
             "}"
         )
@@ -288,7 +288,7 @@ class TransHtmlTest(SimpleTestCase):
                 parameters={"a": "there", "g": "male", "n": 17},
                 tags={"em0": {"tag": "em", "attrs": {}}},
             ),
-            "Hello there, you have 17 little boys",
+            "Hello there, you have 17 boys",
         )
         self.assertEqual(
             trans_html(
@@ -298,7 +298,7 @@ class TransHtmlTest(SimpleTestCase):
                 parameters={"a": "there", "g": "female", "n": 18},
                 tags={"em0": {"tag": "em", "attrs": {}}},
             ),
-            "Hello there, you have 18 little girls",
+            "Hello there, you have 18 girls",
         )
         self.assertEqual(
             trans_html(

--- a/cjworkbench/tests/i18n/test_trans.py
+++ b/cjworkbench/tests/i18n/test_trans.py
@@ -1,12 +1,7 @@
 from django.test import SimpleTestCase
-from cjworkbench.i18n.trans import trans_html, trans, MessageTranslator
-from cjworkbench.i18n import default_locale
+from cjworkbench.i18n.trans import MessageTranslator
 from icu import ICUError
-
-
-mock_message_id = (
-    "some+crazy+id+that+will+never+be+actually+used+in+real+translation+files"
-)
+from babel.messages.catalog import Catalog
 
 
 class TransTest(SimpleTestCase):
@@ -14,111 +9,120 @@ class TransTest(SimpleTestCase):
     # 1) Parameters that do not exist in the message are ignored.
     # 2) Variables in the message for which no parameter has been given are ignored.
     def test_trans_params(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {a} {param_b} {c}!")
         self.assertEqual(
-            trans(
-                mock_message_id,
+            MessageTranslator("en", catalog).trans(
+                "id",
                 default="Hello {a} {param_b} {c}!",
                 parameters={"param_b": "there", "a": "you", "d": "tester"},
             ),
-            "Hello you there {c}!",
+            "Hey you there {c}!",
         )
 
-    # Tests that a programmer will break the system by including an invalid parameter
-    def test_programmer_invalid_parameter_syntax(self):
+    # Tests that a badly formatted parameter in a default message will break the system
+    def test_default_invalid_parameter_syntax(self):
+        catalog = Catalog()
         with self.assertRaises(ICUError):
-            trans(
-                mock_message_id,
-                default="Hello {a b}",
-                parameters={"a": "you", "b": "2"},
+            MessageTranslator("en", catalog).trans(
+                "id", default="Hello {a b}!", parameters={"a": "you", "b": "2"}
             )
 
-    # Tests that a translator can't break our system by including an invalid parameter
-    def test_translator_invalid_parameter_syntax(self):
+    # Tests that badly formatted parameter in a catalog can't break our system
+    def test_message_invalid_parameter_syntax(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {a b}!")
         self.assertEqual(
-            MessageTranslator(default_locale)._process_simple_message(
-                "Hello {a b}", "Hello {a} {b}", parameters={"a": "you", "b": "!"}
+            MessageTranslator("en", catalog).trans(
+                "id", default="Hello {a} {b}", parameters={"a": "you", "b": "!"}
             ),
             "Hello you !",
         )
 
-    # Tests that a programmer can include a numeric variable in the message
-    def test_programmer_numeric_parameter(self):
+    # Tests that a default message can include a numeric variable
+    def test_default_numeric_parameter(self):
+        catalog = Catalog()
         self.assertEqual(
-            trans(
-                mock_message_id,
+            MessageTranslator("en", catalog).trans(
+                "id",
                 default="Hello {a} {0} {b}",
                 parameters={"a": "you", "0": "!", "b": "2"},
             ),
             "Hello you ! 2",
         )
 
-    # Tests that a translator can use a numeric variable in the message
-    def test_translator_numeric_parameter(self):
+    # Tests that a message in catalogs can use a numeric variable
+    def test_message_numeric_parameter(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {a} {0} {b}")
         self.assertEqual(
-            MessageTranslator(default_locale)._process_simple_message(
-                "Hey {a} {0} {b}",
-                "Hello {a} {0} {b}",
+            MessageTranslator("en", catalog).trans(
+                "id",
+                default="Hello {a} {0} {b}",
                 parameters={"a": "you", "b": "!", "0": "there"},
             ),
             "Hey you there !",
         )
 
-    # Tests that a translator can't break our system by adding or removing variables in the message
-    def test_translator_different_parameters(self):
+    # Tests that a message in the catalogs can't break our system by having more or missing variables relative to the default
+    def test_message_different_parameters(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {a} {0} {c}")
         self.assertEqual(
-            MessageTranslator(default_locale)._process_simple_message(
-                "Hey {a} {c}", "Hello {a} {b}", parameters={"a": "you", "b": "!"}
+            MessageTranslator("en", catalog).trans(
+                "id", default="Hello {a} {b}", parameters={"a": "you", "b": "!"}
             ),
-            "Hey you {c}",
+            "Hey you {0} {c}",
         )
 
     # Tests that HTML is not escaped
     def test_no_html_escape(self):
+        catalog = Catalog()
+        catalog.add(
+            "id", string='Hello <a href="/you?a=n&b=e">you > {param_b}</a> my & friend'
+        )
         self.assertEqual(
-            trans(
-                mock_message_id,
-                default='Hello <a href="/you?a=n&b=e">you > {param_b}</a> my & friend',
-                parameters={"param_b": "> there"},
+            MessageTranslator("en", catalog).trans(
+                "id", default="Hello {param_b}", parameters={"param_b": "> there"}
             ),
             'Hello <a href="/you?a=n&b=e">you > > there</a> my & friend',
         )
 
     # Tests that plurals, selects and nested messages are fully supported
     def test_icu_support(self):
-        message = (
-            "Hello {a}, you have {g, select,"
-            "   male {{n, plural,"
-            "       =0 {no boys} one {# boy} other {# boys}"
-            "   }}"
-            "   female {{n, plural,"
-            "       =0 {no girls} one {# girl} other {# girls}"
-            "   }}"
-            "   other {{n, plural,"
-            "       =0 {no children} one {# child} other {# children}"
-            "   }}"
-            "}"
+        catalog = Catalog()
+        catalog.add(
+            "id",
+            string=(
+                "Hello {a}, you have {g, select,"
+                "   male {{n, plural,"
+                "       =0 {no boys} one {# boy} other {# boys}"
+                "   }}"
+                "   female {{n, plural,"
+                "       =0 {no girls} one {# girl} other {# girls}"
+                "   }}"
+                "   other {{n, plural,"
+                "       =0 {no children} one {# child} other {# children}"
+                "   }}"
+                "}"
+            ),
         )
+        default = "Hello {a}, you have {n} child(ren) of gender {g}"
         self.assertEqual(
-            trans(
-                mock_message_id,
-                default=message,
-                parameters={"a": "there", "g": "male", "n": 17},
+            MessageTranslator("en", catalog).trans(
+                "id", default=default, parameters={"a": "there", "g": "male", "n": 17}
             ),
             "Hello there, you have 17 boys",
         )
         self.assertEqual(
-            trans(
-                mock_message_id,
-                default=message,
-                parameters={"a": "there", "g": "female", "n": 18},
+            MessageTranslator("en", catalog).trans(
+                "id", default=default, parameters={"a": "there", "g": "female", "n": 18}
             ),
             "Hello there, you have 18 girls",
         )
         self.assertEqual(
-            trans(
-                mock_message_id,
-                default=message,
-                parameters={"a": "there", "g": "other", "n": 0},
+            MessageTranslator("en", catalog).trans(
+                "id", default=default, parameters={"a": "there", "g": "other", "n": 0}
             ),
             "Hello there, you have no children",
         )
@@ -129,46 +133,70 @@ class TransHtmlTest(SimpleTestCase):
     # 1) Parameters that do not exist in the message are ignored.
     # 2) Variables in the message for which no parameter has been given are ignored.
     def test_trans_params(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {a} {param_b} {c}!")
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
+            MessageTranslator("en", catalog).trans_html(
+                "id",
                 default="Hello {a} {param_b} {c}!",
                 parameters={"param_b": "there", "a": "you", "d": "tester"},
             ),
-            "Hello you there {c}!",
+            "Hey you there {c}!",
         )
 
-    # Tests that a programmer can include a numeric variable in the message
-    def test_programmer_numeric_parameter_html(self):
+    # Tests that a badly formatted parameter in a default message will break the system
+    def test_default_invalid_parameter_syntax(self):
+        catalog = Catalog()
+        with self.assertRaises(ICUError):
+            MessageTranslator("en", catalog).trans_html(
+                "id", default="Hello {a b}!", parameters={"a": "you", "b": "2"}
+            )
+
+    # Tests that badly formatted parameter in a catalog can't break our system
+    def test_message_invalid_parameter_syntax(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {a b}!")
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
+            MessageTranslator("en", catalog).trans_html(
+                "id", default="Hello {a} {b}", parameters={"a": "you", "b": "!"}
+            ),
+            "Hello you !",
+        )
+
+    # Tests that a default message can include a numeric variable
+    def test_default_numeric_parameter(self):
+        catalog = Catalog()
+        self.assertEqual(
+            MessageTranslator("en", catalog).trans_html(
+                "id",
                 default="Hello {a} {0} {b}",
                 parameters={"a": "you", "0": "!", "b": "2"},
             ),
             "Hello you ! 2",
         )
 
-    # Tests that a translator can use a numeric variable in the message
-    def test_translator_numeric_parameter_html(self):
+    # Tests that a message in catalogs can use a numeric variable
+    def test_message_numeric_parameter(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {a} {0} {b}")
         self.assertEqual(
-            MessageTranslator(default_locale)._process_html_message(
-                "Hey {a} {0} {b}",
-                "Hello {a} {0} {b}",
+            MessageTranslator("en", catalog).trans_html(
+                "id",
+                default="Hello {a} {0} {b}",
                 parameters={"a": "you", "b": "!", "0": "there"},
             ),
             "Hey you there !",
         )
 
-    # Tests that a translator can't break our system by adding or removing variables in the message
-    def test_translator_different_parameters_html(self):
+    # Tests that a message in the catalogs can't break our system by having more or missing variables relative to the default
+    def test_message_different_parameters(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {a} {0} {c}")
         self.assertEqual(
-            MessageTranslator(default_locale)._process_html_message(
-                "Hey {a} {c}", "Hello {a} {b}", parameters={"a": "you", "b": "!"}
+            MessageTranslator("en", catalog).trans_html(
+                "id", default="Hello {a} {b}", parameters={"a": "you", "b": "!"}
             ),
-            "Hey you {c}",
+            "Hey you {0} {c}",
         )
 
     # Tests that tags in messages are replaced correctly.
@@ -176,12 +204,13 @@ class TransHtmlTest(SimpleTestCase):
     # 2) Tags in the message but not in `tags` are ignored. At this point, their contents are kept, but this may change in the future.
     # 3) All attributes given for a tag in `tags` are used.
     # 4) Tag attributes existing in the message are ignored.
-    def test_trans_tags(self):
+    def test_tags(self):
+        catalog = Catalog()
+        catalog.add("id", string='<a0 id="nope">Hello</a0><b0>you</b0><div>there</div>')
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
-                default='<a0 id="nope">Hello</a0><b0>you</b0><div>there</div>',
+            MessageTranslator("en", catalog).trans_html(
+                "id",
+                default="<span0>Hello</span0> <a0>{a}</a0>",
                 parameters={"a": "you"},
                 tags={
                     "a0": {
@@ -200,12 +229,13 @@ class TransHtmlTest(SimpleTestCase):
 
     # Tests that nested tags in messages are not tolerated.
     # At this point, nested tags are ignored, but their contents are kept. This may change in the future.
-    def test_trans_nested_tags(self):
+    def test_nested_tags(self):
+        catalog = Catalog()
+        catalog.add("id", string="<a0>Hello<b0>you</b0><div>there</div></a0>")
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
-                default="<a0>Hello<b0>you</b0><div>there</div></a0>",
+            MessageTranslator("en", catalog).trans_html(
+                "id",
+                default="<b0>Hello</b0> <a0>{a}</a0>",
                 parameters={"a": "you"},
                 tags={
                     "a0": {"tag": "a", "attrs": {"href": "/you"}},
@@ -216,12 +246,13 @@ class TransHtmlTest(SimpleTestCase):
         )
 
     # Tests that parameters are substituted within tags
-    def test_trans_params_in_tags(self):
+    def test_params_in_tags(self):
+        catalog = Catalog()
+        catalog.add("id", string="<a0>Hello {name}</a0>{test}")
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
-                default="<a0>Hello {name}</a0>{test}",
+            MessageTranslator("en", catalog).trans_html(
+                "id",
+                default="Hello{test} <a0>{name}</a0>",
                 parameters={"name": "you", "test": "!"},
                 tags={"a0": {"tag": "a", "attrs": {"href": "/you"}}},
             ),
@@ -229,40 +260,43 @@ class TransHtmlTest(SimpleTestCase):
         )
 
     # Tests that special characters in the text are escaped, in any depth
-    def test_trans_escapes_text(self):
+    def test_escapes_text(self):
+        catalog = Catalog()
+        catalog.add("id", string="<a0>Hello &<b>&</b></a0>>")
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
-                default="<a0>Hello &<b>&</b></a0>>",
+            MessageTranslator("en", catalog).trans_html(
+                "id",
+                default="<a0>Hello</a0>",
                 tags={"a0": {"tag": "a", "attrs": {"href": "/you"}}},
             ),
             '<a href="/you">Hello &amp;&amp;</a>&gt;',
         )
 
     # Tests that message parameters are escaped
-    def test_trans_escapes_params(self):
+    def test_escapes_params(self):
+        catalog = Catalog()
+        catalog.add("id", string="<a0>Hey {name}</a0>{test}")
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
+            MessageTranslator("en", catalog).trans_html(
+                "id",
                 default="<a0>Hello {name}</a0>{test}",
                 parameters={"name": "<b>you</b>", "test": "<b>there</b>"},
                 tags={"a0": {"tag": "a", "attrs": {"href": "/you"}}},
             ),
-            '<a href="/you">Hello &lt;b&gt;you&lt;/b&gt;</a>&lt;b&gt;there&lt;/b&gt;',
+            '<a href="/you">Hey &lt;b&gt;you&lt;/b&gt;</a>&lt;b&gt;there&lt;/b&gt;',
         )
 
     # Tests that tag attributes in messages are escaped
-    def test_trans_escapes_tag_attrs(self):
+    def test_escapes_tag_attrs(self):
+        catalog = Catalog()
+        catalog.add("id", string="<a0>Hey</a0>")
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
+            MessageTranslator("en", catalog).trans_html(
+                "id",
                 default="<a0>Hello</a0>",
                 tags={"a0": {"tag": "a", "attrs": {"href": "/you?a=b&c=d"}}},
             ),
-            '<a href="/you?a=b&amp;c=d">Hello</a>',
+            '<a href="/you?a=b&amp;c=d">Hey</a>',
         )
 
     # Tests the combination of properties of placeholder tags and of message parameters.
@@ -273,12 +307,16 @@ class TransHtmlTest(SimpleTestCase):
     # 4) Nested tags are not tolerated
     # 5) `arg_XX` arguments are replaced and escaped correctly
     # 6) The same tag can appear multiple times
-    def test_trans_tag_placeholders(self):
+    def test_tag_placeholders(self):
+        catalog = Catalog()
+        catalog.add(
+            "id",
+            string='<span0 class="nope">Hey {first}</span0><span1></span1> <span0>{second}</span0> <a0>{a}<b></b></a0> < <a1>there<</a1>!<br /><script type="text/javascript" src="mybadscript.js"></script>',
+        )
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
-                default='<span0 class="nope">Hello {first}</span0><span1></span1> <span0>{second}</span0> <a0>{a}<b></b></a0> < <a1>there<</a1>!<br /><script type="text/javascript" src="mybadscript.js"></script>',
+            MessageTranslator("en", catalog).trans_html(
+                "id",
+                default="<span0>Hello</span0> <a0>{a}</a0> <a1>{first} {second}</a1>",
                 parameters={"a": "you", "first": "hello", "second": "&"},
                 tags={
                     "a0": {"tag": "a", "attrs": {"href": "/you"}},
@@ -289,51 +327,44 @@ class TransHtmlTest(SimpleTestCase):
                     "span0": {"tag": "span", "attrs": {"id": "hi"}},
                 },
             ),
-            '<span id="hi">Hello hello</span> <span id="hi">&amp;</span> <a href="/you">you</a> &lt; <a class="red big" href="/there?a=b&amp;c=d">there&lt;</a>!',
+            '<span id="hi">Hey hello</span> <span id="hi">&amp;</span> <a href="/you">you</a> &lt; <a class="red big" href="/there?a=b&amp;c=d">there&lt;</a>!',
         )
 
     # Tests that plurals, selects and nested messages are fully supported
     def test_icu_support(self):
-        message = (
-            "Hello {a}, you have {g, select,"
-            "   male {{n, plural,"
-            "       =0 {<em0>no</em0> boys} one {# boy} other {# boys}"
-            "   }}"
-            "   female {{n, plural,"
-            "       =0 {<em0>no</em0> girls} one {# girl} other {# girls}"
-            "   }}"
-            "   other {{n, plural,"
-            "       =0 {<em0>no</em0> children} one {# child} other {# children}"
-            "   }}"
-            "}"
+        catalog = Catalog()
+        catalog.add(
+            "id",
+            string=(
+                "Hello {a}, you have {g, select,"
+                "   male {{n, plural,"
+                "       =0 {no boys} one {# boy} other {# boys}"
+                "   }}"
+                "   female {{n, plural,"
+                "       =0 {no girls} one {# girl} other {# girls}"
+                "   }}"
+                "   other {{n, plural,"
+                "       =0 {no children} one {# child} other {# children}"
+                "   }}"
+                "}"
+            ),
         )
+        default = "Hello {a}, you have {n} child(ren) of gender {g}"
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
-                default=message,
-                parameters={"a": "there", "g": "male", "n": 17},
-                tags={"em0": {"tag": "em", "attrs": {}}},
+            MessageTranslator("en", catalog).trans_html(
+                "id", default=default, parameters={"a": "there", "g": "male", "n": 17}
             ),
             "Hello there, you have 17 boys",
         )
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
-                default=message,
-                parameters={"a": "there", "g": "female", "n": 18},
-                tags={"em0": {"tag": "em", "attrs": {}}},
+            MessageTranslator("en", catalog).trans_html(
+                "id", default=default, parameters={"a": "there", "g": "female", "n": 18}
             ),
             "Hello there, you have 18 girls",
         )
         self.assertEqual(
-            trans_html(
-                default_locale,
-                mock_message_id,
-                default=message,
-                parameters={"a": "there", "g": "other", "n": 0},
-                tags={"em0": {"tag": "em", "attrs": {}}},
+            MessageTranslator("en", catalog).trans_html(
+                "id", default=default, parameters={"a": "there", "g": "other", "n": 0}
             ),
-            "Hello there, you have <em>no</em> children",
+            "Hello there, you have no children",
         )

--- a/cjworkbench/tests/i18n/test_trans.py
+++ b/cjworkbench/tests/i18n/test_trans.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 from cjworkbench.i18n.trans import MessageTranslator
-from icu import ICUError
+from icu import ICUError, InvalidArgsError
 from babel.messages.catalog import Catalog
 
 
@@ -19,6 +19,33 @@ class TransTest(SimpleTestCase):
             ),
             "Hey you there {c}!",
         )
+
+    # Tests that passing a list as parameters will raise an exception
+    def test_parameters_list(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {0} {1}!")
+        with self.assertRaises(AttributeError):
+            MessageTranslator("en", catalog).trans(
+                "id", default="Hello {0} {1}!", parameters=["you", "there"]
+            )
+
+    # Tests that passing a tuple as parameters will raise an exception
+    def test_parameters_tuple(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {0} {1}!")
+        with self.assertRaises(AttributeError):
+            MessageTranslator("en", catalog).trans(
+                "id", default="Hello {0} {1}!", parameters=("you", "there")
+            )
+
+    # Tests that passing a list as a value for a parameter will raise an exception
+    def test_parameter_list(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {0} {1}!")
+        with self.assertRaises(InvalidArgsError):
+            MessageTranslator("en", catalog).trans(
+                "id", default="Hello {0}!", parameters={"0": ["you ", "there"]}
+            )
 
     # Tests that a badly formatted parameter in a default message will break the system
     def test_default_invalid_parameter_syntax(self):
@@ -143,6 +170,33 @@ class TransHtmlTest(SimpleTestCase):
             ),
             "Hey you there {c}!",
         )
+
+    # Tests that passing a list as parameters will raise an exception
+    def test_parameters_list(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {0} {1}!")
+        with self.assertRaises(AttributeError):
+            MessageTranslator("en", catalog).trans_html(
+                "id", default="Hello {0} {1}!", parameters=["you", "there"]
+            )
+
+    # Tests that passing a tuple as parameters will raise an exception
+    def test_parameters_tuple(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {0} {1}!")
+        with self.assertRaises(AttributeError):
+            MessageTranslator("en", catalog).trans_html(
+                "id", default="Hello {0} {1}!", parameters=("you", "there")
+            )
+
+    # Tests that passing a list as a value for a parameter will raise an exception
+    def test_parameter_list(self):
+        catalog = Catalog()
+        catalog.add("id", string="Hey {0} {1}!")
+        with self.assertRaises(InvalidArgsError):
+            MessageTranslator("en", catalog).trans_html(
+                "id", default="Hello {0}!", parameters={"0": ["you ", "there"]}
+            )
 
     # Tests that a badly formatted parameter in a default message will break the system
     def test_default_invalid_parameter_syntax(self):

--- a/server/tests/templatetags/test_i18n_icu.py
+++ b/server/tests/templatetags/test_i18n_icu.py
@@ -41,7 +41,7 @@ class TransTemplateTagTests(SimpleTestCase):
             "Hello you there {c}!",
         )
 
-        with self.assertRaises(Exception):
+        self.assertEqual(
             trans_html(
                 mock_context(),
                 mock_message_id,
@@ -50,6 +50,8 @@ class TransTemplateTagTests(SimpleTestCase):
                 arg_0="!",
                 arg_b="2",
             ),
+            "Hello you ! 2",
+        )
 
     def test_trans_tag_without_attributes(self):
         self.assertEqual(


### PR DESCRIPTION
This pull request replaces our custom quasi-ICU code with calls to ICU library, in order to support plurals, selects, and nested messages —all of which will be needed for module error messages.