### PR TITLE
Unit test python/django extraction and nix support for context in trans

### DIFF
--- a/cjwkernel/types.py
+++ b/cjwkernel/types.py
@@ -621,14 +621,16 @@ class I18nMessage:
         message_id: str,
         *,
         default: str,
-        parameters: Dict[str, Union[int, float, str]] = {},
+        args: Dict[str, Union[int, float, str]] = {},
     ) -> I18nMessage:
         """
-        Build an I18nMessage.
+        Build an I18nMessage, marking it for translation.
+        
+        Use this method (instead of constructing `I18nMessage` directly) when you wish to mark a string for translation. Workbench's tooling will extract messages from all `I18nMessage.trans()` calls and send them to translators.
 
         The `default` argument is ignored at runtime, it's only used when parsing code.
         """
-        return cls(message_id, parameters)
+        return cls(message_id, args)
 
     @classmethod
     def from_dict(cls, value: Dict[str, Any]) -> I18nMessage:

--- a/cjwkernel/types.py
+++ b/cjwkernel/types.py
@@ -616,6 +616,21 @@ class I18nMessage:
         return cls("TODO_i18n", {"text": text})
 
     @classmethod
+    def trans(
+        cls,
+        message_id: str,
+        *,
+        default: str,
+        parameters: Dict[str, Union[int, float, str]] = {},
+    ) -> I18nMessage:
+        """
+        Build an I18nMessage.
+
+        The `default` argument is ignored at runtime, it's only used when parsing code.
+        """
+        return cls(message_id, parameters)
+
+    @classmethod
     def from_dict(cls, value: Dict[str, Any]) -> I18nMessage:
         return cls(value["id"], value["arguments"])
 

--- a/cjworkbench/i18n/catalogs/extract.py
+++ b/cjworkbench/i18n/catalogs/extract.py
@@ -122,7 +122,6 @@ def extract_python(
         # `messages` will have all the string parameters to our function
         # As we specify in the documentation of `trans`,
         # the first will be the message ID, the second will be the default message
-        # and the (optional) third will be the message context
         if len(messages) > 1 and messages[1]:
             # If we have a default, add it as a special comment
             # that will be processed by our `merge_catalogs` script

--- a/cjworkbench/i18n/catalogs/extract.py
+++ b/cjworkbench/i18n/catalogs/extract.py
@@ -119,35 +119,24 @@ def extract_python(
     for (message_lineno, funcname, messages, translator_comments) in _parse_python(
         fileobj, keywords, comment_tags, options
     ):
-        if funcname in ["trans", "trans_lazy"]:
-            # `messages` will have all the string parameters to our function
-            # As we specify in the documentation of `trans`,
-            # the first will be the message ID, the second will be the default message
-            # and the (optional) third will be the message context
-            if len(messages) > 1 and messages[1]:
-                # If we have a default, add it as a special comment
-                # that will be processed by our `merge_catalogs` script
-                translator_comments.append(
-                    (message_lineno, "default-message: " + messages[1])
-                )
+        # `messages` will have all the string parameters to our function
+        # As we specify in the documentation of `trans`,
+        # the first will be the message ID, the second will be the default message
+        # and the (optional) third will be the message context
+        if len(messages) > 1 and messages[1]:
+            # If we have a default, add it as a special comment
+            # that will be processed by our `merge_catalogs` script
+            translator_comments.append(
+                (message_lineno, "default-message: " + messages[1])
+            )
 
-            if len(messages) > 2 and isinstance(messages[2], str):
-                context = messages[2]
-            else:
-                context = None
+        # Pybabel expects a `funcname` of the `gettext` family, or `None`.
+        funcname = None
 
-            if context:
-                # if we have a context, trick pybabel to use `pgettext`
-                # so that it adds the context to the translation file
-                funcname = "pgettext"
-                messages = [context, messages[0]]
-            else:
-                # Pybabel expects a `funcname` of the `gettext` family, or `None`.
-                funcname = None
         yield (
             message_lineno,
             funcname,
-            messages,
+            messages[0],
             [comment[1] for comment in translator_comments],
         )
 

--- a/cjworkbench/i18n/trans.py
+++ b/cjworkbench/i18n/trans.py
@@ -29,7 +29,7 @@ def _get_translations(locale):
 
 
 def trans(message_id, *, default, parameters={}):
-    """Mark a message for translation and localize it to the current locale, not escaping HTML.
+    """Mark a message for translation and localize it to the current locale.
     
     For code parsing reasons, respect the following order when passing keyword arguments:
         `message_id` and then `default` and then everything else

--- a/cjworkbench/i18n/trans.py
+++ b/cjworkbench/i18n/trans.py
@@ -28,36 +28,33 @@ def _get_translations(locale):
     return _translators[locale]
 
 
-def trans(message_id, *, default, context=None, parameters={}):
-    """Translate the given message ID to the current locale
-    
-    HTML is not escaped.
+def trans(message_id, *, default, parameters={}):
+    """Mark a message for translation and localize it to the current locale, not escaping HTML.
     
     For code parsing reasons, respect the following order when passing keyword arguments:
-        `message_id` and then `default` and then `context` and then everything else
+        `message_id` and then `default` and then everything else
     """
     return _get_translations(get_language()).trans(
-        message_id, default=default, context=context, parameters=parameters
-    )
-
-
-def trans_html(locale_id, message_id, *, default, context=None, parameters={}, tags={}):
-    """Translate the given message ID to the given locale
-    
-    HTML is escaped in the message, as well as in parameters and tag attributes.
-    
-    For code parsing reasons, respect the following order when passing keyword arguments:
-        `message_id` and then `default` and then `context` and then everything else
-    """
-    return _get_translations(locale_id).trans_html(
-        message_id, default=default, context=context, parameters=parameters, tags=tags
+        message_id, default=default, parameters=parameters
     )
 
 
 trans_lazy = lazy(trans)
-"""Mark a string for translation, but actually translate it when it has to be used.
-   See the documentation of `trans` for more details on the parameters.
+"""Mark a string for translation, but actually localize it when it has to be used.
+   See the documentation of `trans` for more details on the function and its parameters.
 """
+
+
+def localize_html(
+    locale_id, message_id, *, default, context=None, parameters={}, tags={}
+):
+    """Localize the given message ID to the given locale, escaping HTML.
+    
+    HTML is escaped in the message, as well as in parameters and tag attributes.
+    """
+    return _get_translations(locale_id).trans_html(
+        message_id, default=default, context=context, parameters=parameters, tags=tags
+    )
 
 
 def restore_tags(message, tag_mapping):
@@ -118,9 +115,7 @@ class MessageTranslator:
         they are handled so as to not raise an exception; at this point, the default message is used instead, but you should not rely on this behaviour
         """
         return self._process_simple_message(
-            self.get_message(message_id, context=context),
-            default or message_id,
-            parameters,
+            self.get_message(message_id, context=context), default, parameters
         )
 
     def trans_html(
@@ -137,10 +132,7 @@ class MessageTranslator:
         HTML-like tags in the message used are replaced by their counterpart in `tags`, as specified in `restore_tags`
         """
         return self._process_html_message(
-            self.get_message(message_id, context=context),
-            default or message_id,
-            parameters,
-            tags,
+            self.get_message(message_id, context=context), default, parameters, tags
         )
 
     def _process_simple_message(self, message, fallback, parameters={}):

--- a/cjworkbench/tests/i18n/catalogs/test_extract.py
+++ b/cjworkbench/tests/i18n/catalogs/test_extract.py
@@ -1,0 +1,211 @@
+import unittest
+from babel.messages.catalog import Catalog
+from cjworkbench.i18n.catalogs.extract import extract_python, extract_django
+from cjworkbench.tests.i18n.catalogs.util import assert_catalogs_deeply_equal
+from io import BytesIO
+from typing import List, Tuple, Union
+
+ExtractionTuple = Tuple[int, str, Union[str, List[str]], List[str]]
+
+
+def _extract_python(code: BytesIO) -> List[ExtractionTuple]:
+    return list(extract_python(code, None, None, {}))
+
+
+def _mock_django_extraction_tuple(
+    lineno: int,
+    message_id: str,
+    default: str,
+    context: str = None,
+    comments: List[str] = [],
+) -> ExtractionTuple:
+    i18n_comments = [f"default-message: {default}"]
+    i18n_comments.extend(comments)
+    if context:
+        return (lineno, "pgettext", [context, message_id], i18n_comments)
+    else:
+        return (lineno, None, message_id, i18n_comments)
+
+
+def _extract_django(code: BytesIO) -> List[ExtractionTuple]:
+    return list(extract_django(code, None, None, {}))
+
+
+def _mock_python_extraction_tuple(
+    lineno: int, message_id: str, default: str, comments: List[str] = []
+) -> ExtractionTuple:
+    i18n_comments = list(comments)
+    i18n_comments.append(f"default-message: {default}")
+    return (lineno, None, message_id, i18n_comments)
+
+
+class ExtractDjangoTest(unittest.TestCase):
+    def test_no_translations(self):
+        code = BytesIO(
+            b"""
+        {% if that %}
+            {{ this }}
+        {% else %}
+            {{ the_other }}
+        {% endif %}
+        """
+        )
+        expected = []
+        self.assertEqual(_extract_django(code), expected)
+
+    def test_trans_html_simple_message(self):
+        code = BytesIO(
+            b"""{% load i18n_icu %}
+    {% trans_html "id" default="default" %}
+        """
+        )
+        expected = [_mock_django_extraction_tuple(2, "id", "default")]
+        self.assertEqual(_extract_django(code), expected)
+
+    def test_trans_html_with_parameters(self):
+        code = BytesIO(
+            b"""{% load i18n_icu %}
+    {% trans_html "id" default="default {a}" arg_a='b' %}
+        """
+        )
+        expected = [_mock_django_extraction_tuple(2, "id", "default {a}")]
+        self.assertEqual(_extract_django(code), expected)
+
+    def test_trans_html_with_parameters_and_comment(self):
+        code = BytesIO(
+            b"""{% load i18n_icu %}
+    {% trans_html "id" default="default {a}" comment="Some comment" arg_a='b' %}
+        """
+        )
+        expected = [
+            _mock_django_extraction_tuple(
+                2, "id", "default {a}", comments=["Some comment"]
+            )
+        ]
+        self.assertEqual(_extract_django(code), expected)
+
+    def test_trans_html_with_tag(self):
+        code = BytesIO(
+            b"""{% load i18n_icu %}
+    {% trans_html "id" default="<a0>default</a0>" tag_a0_href='/b' %}
+        """
+        )
+        expected = [_mock_django_extraction_tuple(2, "id", "<a0>default</a0>")]
+        self.assertEqual(_extract_django(code), expected)
+
+    def test_trans_html_with_context(self):
+        code = BytesIO(
+            b"""{% load i18n_icu %}
+    {% trans_html "id" default="default" ctxt='ctxt' %}
+        """
+        )
+        expected = [_mock_django_extraction_tuple(2, "id", "default", context="ctxt")]
+        self.assertEqual(_extract_django(code), expected)
+
+    def test_trans_html_with_context_and_comment(self):
+        code = BytesIO(
+            b"""{% load i18n_icu %}
+    {% trans_html "id" default="default" ctxt='ctxt' comment="Some comment" %}
+        """
+        )
+        expected = [
+            _mock_django_extraction_tuple(
+                2, "id", "default", context="ctxt", comments=["Some comment"]
+            )
+        ]
+        self.assertEqual(_extract_django(code), expected)
+
+    def test_trans_html_with_context_comment_and_parameters(self):
+        code = BytesIO(
+            b"""{% load i18n_icu %}
+    {% trans_html "id" default="default {a}" ctxt='ctxt' arg_a='b' comment="Some comment" %}
+        """
+        )
+        expected = [
+            _mock_django_extraction_tuple(
+                2, "id", "default {a}", context="ctxt", comments=["Some comment"]
+            )
+        ]
+        self.assertEqual(_extract_django(code), expected)
+
+
+class ExtractPythonTest(unittest.TestCase):
+    def test_no_translations(self):
+        code = BytesIO(
+            b"""
+def test():
+    return 1
+        """
+        )
+        expected = []
+        self.assertEqual(_extract_python(code), expected)
+
+    def test_trans_simple_message(self):
+        code = BytesIO(
+            b"""
+def test():
+    return trans('id', default='default')
+        """
+        )
+        expected = [_mock_python_extraction_tuple(3, "id", "default")]
+        self.assertEqual(_extract_python(code), expected)
+
+    def test_trans_with_parameters(self):
+        code = BytesIO(
+            b"""
+def test():
+    return trans('id', default='default {a}', parameters={'a': 'b'})
+        """
+        )
+        expected = [_mock_python_extraction_tuple(3, "id", "default {a}")]
+        self.assertEqual(_extract_python(code), expected)
+
+    def test_trans_with_comment_and_parameters(self):
+        code = BytesIO(
+            b"""
+def test():
+    # i18n: Some comment
+    return trans('id', default='default {a}', parameters={'a': 'b'})
+        """
+        )
+        expected = [
+            _mock_python_extraction_tuple(
+                4, "id", "default {a}", comments=["i18n: Some comment"]
+            )
+        ]
+        self.assertEqual(_extract_python(code), expected)
+
+    def test_i18n_message_simple_message(self):
+        code = BytesIO(
+            b"""
+def test():
+    return I18nMessage.trans('id', default='default')
+        """
+        )
+        expected = [_mock_python_extraction_tuple(3, "id", "default")]
+        self.assertEqual(_extract_python(code), expected)
+
+    def test_i18n_message_with_parameters(self):
+        code = BytesIO(
+            b"""
+def test():
+    return I18nMessage.trans('id', default='default {a}', parameters={'a': 'b'})
+        """
+        )
+        expected = [_mock_python_extraction_tuple(3, "id", "default {a}")]
+        self.assertEqual(_extract_python(code), expected)
+
+    def test_i18n_message_with_comment_and_parameters(self):
+        code = BytesIO(
+            b"""
+def test():
+    # i18n: Some comment
+    return I18nMessage.trans('id', default='default {a}', parameters={'a': 'b'})
+        """
+        )
+        expected = [
+            _mock_python_extraction_tuple(
+                4, "id", "default {a}", comments=["i18n: Some comment"]
+            )
+        ]
+        self.assertEqual(_extract_python(code), expected)

--- a/server/templatetags/i18n_icu.py
+++ b/server/templatetags/i18n_icu.py
@@ -2,7 +2,7 @@ import logging
 from django import template
 from django.utils.safestring import mark_safe
 from cjworkbench.i18n import default_locale
-from cjworkbench.i18n.trans import trans_html as do_trans_html
+from cjworkbench.i18n.trans import localize_html
 import re
 
 logger = logging.getLogger(__name__)
@@ -119,7 +119,7 @@ def trans_html(
         locale_id = default_locale
 
     return mark_safe(
-        do_trans_html(
+        localize_html(
             locale_id,
             message_id,
             default=default,


### PR DESCRIPTION
Support for message context in `trans` was interfering with message parameters. Since we don't use it (and are not planning to use it), I removed the support for it.

Now the behaviour of extraction scripts is unit tested. Also, `I18nMessage` type in cjwkernel has a trans function which is extracted normally.

`trans_html` was renamed to `localize_html`, in order to emphasize its different nature from `trans`; it's not expected to be parsed by pybabel and it expects a locale argument.