### PR TITLE
Remove a signal receiver that creates problems

### DIFF
--- a/cjworkbench/models/userprofile.py
+++ b/cjworkbench/models/userprofile.py
@@ -47,8 +47,3 @@ class UserProfile(models.Model):
 
     def __str__(self):
         return user_display(self.user) + " (" + self.user.email + ")"
-
-    @receiver(post_save, sender=User)
-    def handle_user_save(sender, instance, created, **kwargs):
-        if created:
-            UserProfile.objects.get_or_create(user=instance)

--- a/server/tests/handlers/test_autofetch.py
+++ b/server/tests/handlers/test_autofetch.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from server.handlers.autofetch import list_autofetches_json, isoformat
 from cjwstate.models import Workflow
 from cjwstate.tests.utils import DbTestCase
+from cjworkbench.models.userprofile import UserProfile
 
 
 IsoDate1 = "2019-06-18T19:35:57.123Z"
@@ -23,8 +24,9 @@ class AutoupdateTest(DbTestCase):
 
     def test_list_autofetches_gets_user_max_fetches_per_day(self):
         user = User.objects.create(username="a", email="a@example.org")
-        user.user_profile.max_fetches_per_day = 6000
-        user.user_profile.save(update_fields=["max_fetches_per_day"])
+        UserProfile.objects.update_or_create(
+            user=user, defaults={"max_fetches_per_day": 6000}
+        )
         Workflow.create_and_init(owner=user)
         result = list_autofetches_json({"user": user, "session": None})
         self.assertEqual(
@@ -36,7 +38,7 @@ class AutoupdateTest(DbTestCase):
         # it is. So here we are -- sometimes it doesn't exist.
         user = User.objects.create(username="a", email="a@example.org")
         Workflow.create_and_init(owner=user)
-        user.user_profile.delete()
+        UserProfile.objects.filter(user=user).delete()
         user.refresh_from_db()
         result = list_autofetches_json({"user": user, "session": None})
         self.assertEqual(

--- a/server/tests/handlers/test_autofetch.py
+++ b/server/tests/handlers/test_autofetch.py
@@ -24,9 +24,7 @@ class AutoupdateTest(DbTestCase):
 
     def test_list_autofetches_gets_user_max_fetches_per_day(self):
         user = User.objects.create(username="a", email="a@example.org")
-        UserProfile.objects.update_or_create(
-            user=user, defaults={"max_fetches_per_day": 6000}
-        )
+        UserProfile.objects.create(user=user, max_fetches_per_day=6000)
         Workflow.create_and_init(owner=user)
         result = list_autofetches_json({"user": user, "session": None})
         self.assertEqual(

--- a/server/tests/handlers/test_wf_module.py
+++ b/server/tests/handlers/test_wf_module.py
@@ -565,9 +565,7 @@ class WfModuleTest(HandlerTestCase):
 
     def test_try_set_autofetch_exceed_quota(self):
         user = User.objects.create(username="a", email="a@example.org")
-        UserProfile.objects.update_or_create(
-            user=user, defaults={"max_fetches_per_day": 10}
-        )
+        UserProfile.objects.create(user=user, max_fetches_per_day=10)
         workflow = Workflow.create_and_init(owner=user)
         wf_module = workflow.tabs.first().wf_modules.create(order=0, slug="step-1")
         response = self.run_handler(
@@ -590,9 +588,7 @@ class WfModuleTest(HandlerTestCase):
 
     def test_try_set_autofetch_allow_exceed_quota_when_reducing(self):
         user = User.objects.create(username="a", email="a@example.org")
-        UserProfile.objects.update_or_create(
-            user=user, defaults={"max_fetches_per_day": 10}
-        )
+        UserProfile.objects.create(user=user, max_fetches_per_day=10)
         workflow = Workflow.create_and_init(owner=user)
         wf_module = workflow.tabs.first().wf_modules.create(
             order=0,

--- a/server/tests/handlers/test_wf_module.py
+++ b/server/tests/handlers/test_wf_module.py
@@ -29,6 +29,7 @@ from server.handlers.wf_module import (
     clear_file_upload_api_token,
 )
 from .util import HandlerTestCase
+from cjworkbench.models.userprofile import UserProfile
 
 
 async def async_noop(*args, **kwargs):
@@ -564,8 +565,9 @@ class WfModuleTest(HandlerTestCase):
 
     def test_try_set_autofetch_exceed_quota(self):
         user = User.objects.create(username="a", email="a@example.org")
-        user.user_profile.max_fetches_per_day = 10
-        user.user_profile.save()
+        UserProfile.objects.update_or_create(
+            user=user, defaults={"max_fetches_per_day": 10}
+        )
         workflow = Workflow.create_and_init(owner=user)
         wf_module = workflow.tabs.first().wf_modules.create(order=0, slug="step-1")
         response = self.run_handler(
@@ -588,8 +590,9 @@ class WfModuleTest(HandlerTestCase):
 
     def test_try_set_autofetch_allow_exceed_quota_when_reducing(self):
         user = User.objects.create(username="a", email="a@example.org")
-        user.user_profile.max_fetches_per_day = 10
-        user.user_profile.save()
+        UserProfile.objects.update_or_create(
+            user=user, defaults={"max_fetches_per_day": 10}
+        )
         workflow = Workflow.create_and_init(owner=user)
         wf_module = workflow.tabs.first().wf_modules.create(
             order=0,


### PR DESCRIPTION
When `allauth` saved a new user during social login, the deleted receiver would create a default user profile (hence with the default locale id). That default profile would be used later, instead of the updated one, when trying to read the user profile and write the cookie locale, resulting in the user seeing the default locale after login and not the locale in their (updated) profile.