### PR TITLE
Internationalize error messages in renderer.execute.types

### DIFF
--- a/assets/locale/el/messages.po
+++ b/assets/locale/el/messages.po
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 #: assets/js/Embed.js:99
 msgid "js.Embed.embedCode"
@@ -1954,6 +1954,33 @@ msgstr "Όνομα"
 #: cjworkbench/forms/signup.py:31
 msgid "py.forms.signup.lastName.placeholder"
 msgstr "Επώνυμο"
+
+#: renderer/execute/types.py:95
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.shouldBeText"
+msgstr ""
+
+#. i18n: The parameters {found_type} and {best_wanted_type} will have values
+#. among "text", "number", "datetime"; however, including an (possibly empty)
+#. "other" case is mandatory.
+#: renderer/execute/types.py:101
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.general"
+msgstr ""
+
+#. i18n: The parameter {columns} will contain the total number of columns that
+#. need to be converted; you will also receive the column names as {0}, {1},
+#. {2}, etc.
+#: renderer/execute/types.py:144
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.shouldBeText"
+msgstr ""
+
+#. i18n: The parameter {columns} will contain the total number of columns that
+#. need to be converted; you will also receive the column names: {0}, {1}, {2},
+#. etc. The parameters {found_type} and {best_wanted_type} will have values
+#. among "text", "number", "datetime"; however, including a (possibly empty)
+#. "other" case is mandatory.
+#: renderer/execute/types.py:157
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.general"
+msgstr ""
 
 #: templates/403.html:5
 msgid "py.templates.403.title"

--- a/assets/locale/en/messages.po
+++ b/assets/locale/en/messages.po
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 #: assets/js/Embed.js:99
 msgid "js.Embed.embedCode"
@@ -1911,6 +1911,54 @@ msgstr "First name"
 #: cjworkbench/forms/signup.py:31
 msgid "py.forms.signup.lastName.placeholder"
 msgstr "Last name"
+
+#: renderer/execute/types.py:95
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.shouldBeText"
+msgstr "Convert to Text."
+
+#. i18n: The parameters {found_type} and {best_wanted_type} will have values
+#. among "text", "number", "datetime"; however, including an (possibly empty)
+#. "other" case is mandatory.
+#: renderer/execute/types.py:101
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.general"
+msgstr ""
+"Convert { found_type, select, text {Text} number {Numbers} datetime "
+"{Dates & Times} other {}} to {best_wanted_type, select, text {Text} "
+"number {Numbers} datetime {Dates & Times} other{}}."
+
+#. i18n: The parameter {columns} will contain the total number of columns that
+#. need to be converted; you will also receive the column names as {0}, {1},
+#. {2}, etc.
+#: renderer/execute/types.py:144
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.shouldBeText"
+msgstr ""
+"{ columns, plural, offset:2 =1 {The column “{0}” must be converted to "
+"Text.} =2 {The columns “{0}” and “{1}” must be converted to Text.} one "
+"{The columns “{0}”, “{1}” and “{2}” must be converted to Text.} other "
+"{The columns “{0}”, “{1}” and # others must be converted to Text.}}"
+
+#. i18n: The parameter {columns} will contain the total number of columns that
+#. need to be converted; you will also receive the column names: {0}, {1}, {2},
+#. etc. The parameters {found_type} and {best_wanted_type} will have values
+#. among "text", "number", "datetime"; however, including a (possibly empty)
+#. "other" case is mandatory.
+#: renderer/execute/types.py:157
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.general"
+msgstr ""
+"{ columns, plural, offset:2 =1 {The column “{0}” must be converted from {"
+" found_type, select, text {Text} number {Numbers} datetime {Dates & "
+"Times} other {}} to {best_wanted_type, select, text {Text} number "
+"{Numbers} datetime {Dates & Times} other {}}.} =2 {The columns “{0}” and "
+"“{1}” must be converted from { found_type, select, text {Text} number "
+"{Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, "
+"select, text {Text} number {Numbers} datetime {Dates & Times}  other{}}.}"
+" one {The columns “{0}”, “{1}” and “{2}” must be converted from { "
+"found_type, select, text {Text} number {Numbers} datetime {Dates & Times}"
+" other {}} to {best_wanted_type, select, text {Text} number {Numbers} "
+"datetime {Dates & Times} other{}}.} other {The columns “{0}”, “{1}” and #"
+" others must be converted from { found_type, select, text {Text} number "
+"{Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, "
+"select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.}}"
 
 #: templates/403.html:5
 msgid "py.templates.403.title"

--- a/assets/locale/en/messages.pot
+++ b/assets/locale/en/messages.pot
@@ -2270,6 +2270,37 @@ msgstr ""
 msgid "py.forms.signup.lastName.placeholder"
 msgstr ""
 
+#. default-message: Convert to Text.
+#: renderer/execute/types.py:95
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.shouldBeText"
+msgstr ""
+
+#. i18n: The parameters {found_type} and {best_wanted_type} will have values
+#. among "text", "number", "datetime"; however, including an (possibly empty)
+#. "other" case is mandatory.
+#. default-message: Convert { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.
+#: renderer/execute/types.py:101
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.general"
+msgstr ""
+
+#. i18n: The parameter {columns} will contain the total number of columns that
+#. need to be converted; you will also receive the column names as {0}, {1},
+#. {2}, etc.
+#. default-message: { columns, plural, offset:2 =1 {The column “{0}” must be converted to Text.} =2 {The columns “{0}” and “{1}” must be converted to Text.} one {The columns “{0}”, “{1}” and “{2}” must be converted to Text.} other {The columns “{0}”, “{1}” and # others must be converted to Text.}}
+#: renderer/execute/types.py:144
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.shouldBeText"
+msgstr ""
+
+#. i18n: The parameter {columns} will contain the total number of columns that
+#. need to be converted; you will also receive the column names: {0}, {1}, {2},
+#. etc. The parameters {found_type} and {best_wanted_type} will have values
+#. among "text", "number", "datetime"; however, including a (possibly empty)
+#. "other" case is mandatory.
+#. default-message: { columns, plural, offset:2 =1 {The column “{0}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}}.} =2 {The columns “{0}” and “{1}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times}  other{}}.} one {The columns “{0}”, “{1}” and “{2}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.} other {The columns “{0}”, “{1}” and # others must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.}}
+#: renderer/execute/types.py:157
+msgid "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.general"
+msgstr ""
+
 #. default-message: 403 Forbidden
 #: templates/403.html:5
 msgid "py.templates.403.title"

--- a/cjworkbench/i18n/catalogs/util.py
+++ b/cjworkbench/i18n/catalogs/util.py
@@ -14,18 +14,30 @@ def message_unique_identifier(message: Message) -> MessageUID:
     return message.id if not message.context else (message.id, message.context)
 
 
+def find_message(
+    catalog: Catalog, message_id: str, context: Optional[str] = None
+) -> Optional[Message]:
+    message = catalog.get(message_id, context=context)
+    return message if message else None
+
+
+def find_string(
+    catalog: Catalog, message_id: str, context: Optional[str] = None
+) -> Optional[Message]:
+    message = find_message(catalog, message_id, context=context)
+    return message.string if message else None
+
+
 def find_corresponding_message(catalog: Catalog, message: Message) -> Optional[Message]:
     """ Search the catalog for a message with the same ID (and context) and return it.
     """
-    message = catalog.get(message.id, context=message.context)
-    return message if message else None
+    return find_message(catalog, message.id, context=message.context)
 
 
 def find_corresponding_string(catalog: Catalog, message: Message) -> Optional[str]:
     """ Search the catalog for a message with the same ID (and context) and return its string.
     """
-    corresponding_message = find_corresponding_message(catalog, message)
-    return corresponding_message.string if corresponding_message else None
+    return find_string(catalog, message.id, context=message.context)
 
 
 def remove_strings(catalog: Catalog):

--- a/cjworkbench/i18n/trans.py
+++ b/cjworkbench/i18n/trans.py
@@ -33,13 +33,12 @@ _TagMapping = Dict[str, _Tag]
 _Parameters = Dict[str, Union[int, float, str]]
 
 
-def trans(
-    message_id: str, *, default: str, parameters: _Parameters = {}
-) -> Optional[str]:
+def trans(message_id: str, *, default: str, parameters: _Parameters = {}) -> str:
     """Mark a message for translation and localize it to the current locale.
 
     `default` is only considered when parsing code for message extraction.
-    If the message is not found in the catalog for the current or the default locale, return `None`.
+    If the message is not found in the catalog for the current or the default locale, return `None`,
+    raise `KeyError`.
     
     For code parsing reasons, respect the following order when passing keyword arguments:
         `message_id` and then `default` and then everything else
@@ -53,16 +52,19 @@ trans_lazy = lazy(trans)
 """
 
 
-def localize(
-    locale_id: str, message_id: str, parameters: _Parameters = {}
-) -> Optional[str]:
+def localize(locale_id: str, message_id: str, parameters: _Parameters = {}) -> str:
     """Localize the given message ID to the given locale.
 
-    If the message is not found in the catalog for the given or the default locale, return `None`.
+    If the message is not found in the catalog for the given or the default locale, return `None`,
+    raise `KeyError`.
     """
-    return _get_translations(locale_id).trans(
+    message = _get_translations(locale_id).trans(
         message_id, parameters=parameters
     ) or _get_translations(default_locale).trans(message_id, parameters=parameters)
+    if message:
+        return message
+    else:
+        raise KeyError(message_id)
 
 
 def localize_html(
@@ -71,18 +73,23 @@ def localize_html(
     context: Optional[str] = None,
     parameters: _Parameters = {},
     tags: _TagMapping = {},
-) -> Optional[str]:
+) -> str:
     """Localize the given message ID to the given locale, escaping HTML.
     
-    If the message is not found in the catalog for the given or the default locale, return `None`.
+    If the message is not found in the catalog for the given or the default locale,
+    raise `KeyError`.
     
     HTML is escaped in the message, as well as in parameters and tag attributes.
     """
-    return _get_translations(locale_id).trans_html(
+    message = _get_translations(locale_id).trans_html(
         message_id, context=context, parameters=parameters, tags=tags
     ) or _get_translations(default_locale).trans_html(
         message_id, context=context, parameters=parameters, tags=tags
     )
+    if message:
+        return message
+    else:
+        raise KeyError(message_id)
 
 
 def restore_tags(message: str, tag_mapping: _TagMapping) -> str:

--- a/cjworkbench/i18n/trans.py
+++ b/cjworkbench/i18n/trans.py
@@ -4,9 +4,12 @@ from django.utils.html import escape
 from django.utils.translation import get_language
 from cjworkbench.i18n import default_locale
 from cjworkbench.i18n.catalogs import load_catalog
+from cjworkbench.i18n.catalogs.util import find_string
 from string import Formatter
 from cjworkbench.i18n.exceptions import UnsupportedLocaleError, BadCatalogsError
 from icu import Formattable, Locale, MessageFormat, ICUError
+from babel.messages.catalog import Catalog, Message
+from typing import Dict, Union, Optional
 import logging
 
 
@@ -16,27 +19,32 @@ _translators = {}
 logger = logging.getLogger(__name__)
 
 
-def _get_translations(locale):
-    """Return a singleton MessageTranslator for the given locale.
-    
-    In order to parse the message catalogs only once per locale,
-    uses the _translators dict to store the created MessageTranslator for each locale.
-    """
-    if locale in _translators:
-        return _translators[locale]
-    _translators[locale] = MessageTranslator.for_application_messages(locale)
-    return _translators[locale]
+_TagAttributes = Dict[str, str]
+""" Each attribute name is mapped to its value
+"""
+_Tag = Dict[str, Union[str, _TagAttributes]]
+""" Has two keys: 'name': str, and 'attrs': _TagAttributes. 'attrs' is optional
+"""
+# We can define `_Tag` more precisely in python 3.8 used a `TypedDict`
+_TagMapping = Dict[str, _Tag]
+""" Maps each tag to its data
+"""
+
+_Parameters = Dict[str, Union[int, float, str]]
 
 
-def trans(message_id, *, default, parameters={}):
+def trans(
+    message_id: str, *, default: str, parameters: _Parameters = {}
+) -> Optional[str]:
     """Mark a message for translation and localize it to the current locale.
+
+    `default` is only considered when parsing code for message extraction.
+    If the message is not found in the catalog for the current or the default locale, return `None`.
     
     For code parsing reasons, respect the following order when passing keyword arguments:
         `message_id` and then `default` and then everything else
     """
-    return _get_translations(get_language()).trans(
-        message_id, default=default, parameters=parameters
-    )
+    return localize(get_language(), message_id, parameters=parameters)
 
 
 trans_lazy = lazy(trans)
@@ -45,26 +53,39 @@ trans_lazy = lazy(trans)
 """
 
 
-def localize(locale_id, message_id, *, default, parameters={}):
-    """Localize the given message ID to the given locale."""
+def localize(
+    locale_id: str, message_id: str, parameters: _Parameters = {}
+) -> Optional[str]:
+    """Localize the given message ID to the given locale.
+
+    If the message is not found in the catalog for the given or the default locale, return `None`.
+    """
     return _get_translations(locale_id).trans(
-        message_id, default=default, parameters=parameters
-    )
+        message_id, parameters=parameters
+    ) or _get_translations(default_locale).trans(message_id, parameters=parameters)
 
 
 def localize_html(
-    locale_id, message_id, *, default, context=None, parameters={}, tags={}
-):
+    locale_id: str,
+    message_id: str,
+    context: Optional[str] = None,
+    parameters: _Parameters = {},
+    tags: _TagMapping = {},
+) -> Optional[str]:
     """Localize the given message ID to the given locale, escaping HTML.
+    
+    If the message is not found in the catalog for the given or the default locale, return `None`.
     
     HTML is escaped in the message, as well as in parameters and tag attributes.
     """
     return _get_translations(locale_id).trans_html(
-        message_id, default=default, context=context, parameters=parameters, tags=tags
+        message_id, context=context, parameters=parameters, tags=tags
+    ) or _get_translations(default_locale).trans_html(
+        message_id, context=context, parameters=parameters, tags=tags
     )
 
 
-def restore_tags(message, tag_mapping):
+def restore_tags(message: str, tag_mapping: _TagMapping) -> str:
     """Replace the HTML tags and attributes in a message.
     
     `tag_mapping` is a dict that for each tag name contains a new name `name` and new attributes `attrs`
@@ -103,7 +124,7 @@ class MessageTranslator:
       - our HTML placeholder construct.
     """
 
-    def __init__(self, locale_id, catalog):
+    def __init__(self, locale_id: str, catalog: Catalog):
         self.icu_locale = Locale.createFromName(locale_id)
         self.catalog = catalog
         self.locale_id = locale_id
@@ -112,37 +133,42 @@ class MessageTranslator:
     def for_application_messages(cls, locale_id: str):
         return cls(locale_id, load_catalog(locale_id))
 
-    def trans(self, message_id, default=None, context=None, parameters={}):
+    def trans(
+        self,
+        message_id: str,
+        context: Optional[str] = None,
+        parameters: _Parameters = {},
+    ) -> Optional[str]:
         """Find the message corresponding to the given ID in the catalog and format it according to the given parameters.
-        If the message is either not found or empty and a non-empty `default` is provided, the `default` is used instead.
+        If the message is either not found or empty or incorrectly formatted, `None` is returned.
         
-        See `self._format_message` for acceptable types of the parameters argument.
-        
-        In case a message from the catalogs is used, if the message contains illegal (i.e. numeric) variables, 
-        they are handled so as to not raise an exception; at this point, the default message is used instead, but you should not rely on this behaviour
+        See `self._format_message` for acceptable types of the `parameters` argument.
         """
         return self._process_simple_message(
-            self.get_message(message_id, context=context), default, parameters
+            message_id, self.get_message(message_id, context=context), parameters
         )
 
     def trans_html(
-        self, message_id, default=None, context=None, parameters={}, tags={}
-    ):
+        self,
+        message_id: str,
+        context: Optional[str] = None,
+        parameters: _Parameters = {},
+        tags: _TagMapping = {},
+    ) -> Optional[str]:
         """Find the message corresponding to the given ID in the catalog and format it according to the given parameters.
-        If the message is either not found or empty and a non-empty `default` is provided, the `default` is used instead.
+        If the message is either not found or empty or incorrectly formatted, `None` is returned.
         
         See `self._format_message` for acceptable types of the parameters argument.
-        
-        In case a message from the catalogs is used, if the message contains illegal (i.e. numeric) variables, 
-        they are handled so as to not raise an exception; at this point, the default message is used instead, but you should not rely on this behaviour
         
         HTML-like tags in the message used are replaced by their counterpart in `tags`, as specified in `restore_tags`
         """
         return self._process_html_message(
-            self.get_message(message_id, context=context), default, parameters, tags
+            message_id, self.get_message(message_id, context=context), parameters, tags
         )
 
-    def _process_simple_message(self, message, fallback, parameters={}):
+    def _process_simple_message(
+        self, message_id: str, message: Optional[str], parameters: _Parameters = {}
+    ) -> Optional[str]:
         if message:
             try:
                 return self._format_message(
@@ -150,12 +176,18 @@ class MessageTranslator:
                 )
             except ICUError as err:
                 logger.exception(
-                    f"Error in po file for locale {self.locale_id} and message {message}: {err}"
+                    f"Error in po file for locale {self.locale_id} and message {message_id}: {err}"
                 )
                 # ... and fall through to default
-        return self._format_message(fallback, parameters=parameters, html_escape=False)
+        return None
 
-    def _process_html_message(self, message, fallback, parameters={}, tags={}):
+    def _process_html_message(
+        self,
+        message_id: str,
+        message: Optional[str],
+        parameters: _Parameters = {},
+        tags: _TagMapping = {},
+    ) -> Optional[str]:
         if message:
             try:
                 return self._format_message(
@@ -165,14 +197,12 @@ class MessageTranslator:
                 )
             except ICUError as err:
                 logger.exception(
-                    f"Error in po file for locale {self.locale_id} and message {message}: {err}"
+                    f"Error in po file for locale {self.locale_id} and message {message_id}: {err}"
                 )
                 # ... and fall through to default
-        return self._format_message(
-            self._replace_tags(fallback, tags), parameters=parameters, html_escape=True
-        )
+        return None
 
-    def _replace_tags(self, target_message, tags):
+    def _replace_tags(self, target_message: str, tags: _TagMapping) -> str:
         """Replace non-nested tag names and attributes of the `target_message` with the corresponding ones in `tags`
         
         `tags` must be a dict that maps each placeholder in `target_message` to its original tag and attrs,
@@ -180,14 +210,14 @@ class MessageTranslator:
         """
         return restore_tags(target_message, tag_mapping=tags)
 
-    def _format_message(self, message, parameters={}, html_escape=True):
+    def _format_message(
+        self, message: str, parameters: _Parameters = {}, html_escape: bool = True
+    ) -> str:
         """Substitute parameters into ICU-style message.
         You can have variable substitution, plurals, selects and nested messages.
         
         The parameters must be a dict
         """
-        if not message:
-            return message
         message_format = MessageFormat(message, self.icu_locale)
         return message_format.format(
             list(parameters.keys()),
@@ -197,13 +227,23 @@ class MessageTranslator:
             ],
         )
 
-    def get_message(self, message_id, context=None):
+    def get_message(
+        self, message_id: str, context: Optional[str] = None
+    ) -> Optional[str]:
         """Find the message corresponding to the given ID in the catalog.
         
         If the message is not found, `None` is returned.
         """
-        if context:
-            message = self.catalog.get(message_id, context)
-        else:
-            message = self.catalog.get(message_id)
-        return message.string if message else None
+        return find_string(self.catalog, message_id, context=context)
+
+
+def _get_translations(locale: str) -> MessageTranslator:
+    """Return a singleton MessageTranslator for the given locale.
+    
+    In order to parse the message catalogs only once per locale,
+    uses the _translators dict to store the created MessageTranslator for each locale.
+    """
+    if locale in _translators:
+        return _translators[locale]
+    _translators[locale] = MessageTranslator.for_application_messages(locale)
+    return _translators[locale]

--- a/cjworkbench/i18n/trans.py
+++ b/cjworkbench/i18n/trans.py
@@ -45,6 +45,13 @@ trans_lazy = lazy(trans)
 """
 
 
+def localize(locale_id, message_id, *, default, parameters={}):
+    """Localize the given message ID to the given locale."""
+    return _get_translations(locale_id).trans(
+        message_id, default=default, parameters=parameters
+    )
+
+
 def localize_html(
     locale_id, message_id, *, default, context=None, parameters={}, tags={}
 ):

--- a/cjworkbench/tests/i18n/test_trans.py
+++ b/cjworkbench/tests/i18n/test_trans.py
@@ -389,7 +389,8 @@ class LocalizeTest(SimpleTestCase):
             return MessageTranslator(locale, Catalog())
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
-            self.assertIsNone(localize("el", "id"))
+            with self.assertRaises(KeyError):
+                localize("el", "id")
 
     # Tests that badly formatted parameter in a catalog can't break our system
     def test_message_invalid_parameter_syntax(self):
@@ -435,7 +436,8 @@ class LocalizeHtmlTest(SimpleTestCase):
             return MessageTranslator(locale, Catalog())
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
-            self.assertIsNone(localize_html("el", "id"))
+            with self.assertRaises(KeyError):
+                localize_html("el", "id")
 
     # Tests that badly formatted parameter in a catalog can't break our system
     def test_message_invalid_parameter_syntax(self):

--- a/cjworkbench/tests/i18n/test_trans.py
+++ b/cjworkbench/tests/i18n/test_trans.py
@@ -13,7 +13,7 @@ class MessageTranslatorFormatTest(SimpleTestCase):
         with self.assertRaises(KeyError):
             MessageTranslator("en", catalog).get_and_format_message("id")
 
-    # Tests that `parameters` argument replaces variables in the message.
+    # Tests that `arguments` argument replaces variables in the message.
     # 1) Parameters that do not exist in the message are ignored.
     # 2) Variables in the message for which no parameter has been given are ignored.
     def test_trans_params(self):
@@ -21,27 +21,27 @@ class MessageTranslatorFormatTest(SimpleTestCase):
         catalog.add("id", string="Hey {a} {param_b} {c}!")
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"param_b": "there", "a": "you", "d": "tester"}
+                "id", arguments={"param_b": "there", "a": "you", "d": "tester"}
             ),
             "Hey you there {c}!",
         )
 
-    # Tests that passing a list as parameters will raise an exception
-    def test_parameters_list(self):
+    # Tests that passing a list as arguments will raise an exception
+    def test_arguments_list(self):
         catalog = Catalog()
         catalog.add("id", string="Hey {0} {1}!")
         with self.assertRaises(AttributeError):
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters=["you", "there"]
+                "id", arguments=["you", "there"]
             )
 
-    # Tests that passing a tuple as parameters will raise an exception
-    def test_parameters_tuple(self):
+    # Tests that passing a tuple as arguments will raise an exception
+    def test_arguments_tuple(self):
         catalog = Catalog()
         catalog.add("id", string="Hey {0} {1}!")
         with self.assertRaises(AttributeError):
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters=("you", "there")
+                "id", arguments=("you", "there")
             )
 
     # Tests that passing a list as a value for a parameter will raise an exception
@@ -50,7 +50,7 @@ class MessageTranslatorFormatTest(SimpleTestCase):
         catalog.add("id", string="Hey {0} {1}!")
         with self.assertRaises(InvalidArgsError):
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"0": ["you ", "there"]}
+                "id", arguments={"0": ["you ", "there"]}
             )
 
     # Tests that badly formatted parameter in a catalog raises `ICUError`
@@ -59,7 +59,7 @@ class MessageTranslatorFormatTest(SimpleTestCase):
         catalog.add("id", string="Hey {a b}!")
         with self.assertRaises(ICUError):
             result = MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"a": "you", "b": "!"}
+                "id", arguments={"a": "you", "b": "!"}
             )
 
     # Tests that a message in catalogs can use a numeric variable
@@ -68,18 +68,18 @@ class MessageTranslatorFormatTest(SimpleTestCase):
         catalog.add("id", string="Hey {a} {0} {b}")
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"a": "you", "b": "!", "0": "there"}
+                "id", arguments={"a": "you", "b": "!", "0": "there"}
             ),
             "Hey you there !",
         )
 
     # Tests that a message in the catalogs can't break our system by having more or missing variables relative to the default
-    def test_message_different_parameters(self):
+    def test_message_different_arguments(self):
         catalog = Catalog()
         catalog.add("id", string="Hey {a} {0} {c}")
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"a": "you", "b": "!"}
+                "id", arguments={"a": "you", "b": "!"}
             ),
             "Hey you {0} {c}",
         )
@@ -92,7 +92,7 @@ class MessageTranslatorFormatTest(SimpleTestCase):
         )
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"param_b": "> there"}
+                "id", arguments={"param_b": "> there"}
             ),
             'Hello <a href="/you?a=n&b=e">you > > there</a> my & friend',
         )
@@ -118,19 +118,19 @@ class MessageTranslatorFormatTest(SimpleTestCase):
         )
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"a": "there", "g": "male", "n": 17}
+                "id", arguments={"a": "there", "g": "male", "n": 17}
             ),
             "Hello there, you have 17 boys",
         )
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"a": "there", "g": "female", "n": 18}
+                "id", arguments={"a": "there", "g": "female", "n": 18}
             ),
             "Hello there, you have 18 girls",
         )
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_message(
-                "id", parameters={"a": "there", "g": "other", "n": 0}
+                "id", arguments={"a": "there", "g": "other", "n": 0}
             ),
             "Hello there, you have no children",
         )
@@ -143,7 +143,7 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         with self.assertRaises(KeyError):
             MessageTranslator("en", catalog).get_and_format_html_message("id")
 
-    # Tests that `parameters` argument replaces variables in the message.
+    # Tests that `arguments` argument replaces variables in the message.
     # 1) Parameters that do not exist in the message are ignored.
     # 2) Variables in the message for which no parameter has been given are ignored.
     def test_trans_params(self):
@@ -151,27 +151,27 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         catalog.add("id", string="Hey {a} {param_b} {c}!")
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters={"param_b": "there", "a": "you", "d": "tester"}
+                "id", arguments={"param_b": "there", "a": "you", "d": "tester"}
             ),
             "Hey you there {c}!",
         )
 
-    # Tests that passing a list as parameters will raise an exception
-    def test_parameters_list(self):
+    # Tests that passing a list as arguments will raise an exception
+    def test_arguments_list(self):
         catalog = Catalog()
         catalog.add("id", string="Hey {0} {1}!")
         with self.assertRaises(AttributeError):
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters=["you", "there"]
+                "id", arguments=["you", "there"]
             )
 
-    # Tests that passing a tuple as parameters will raise an exception
-    def test_parameters_tuple(self):
+    # Tests that passing a tuple as arguments will raise an exception
+    def test_arguments_tuple(self):
         catalog = Catalog()
         catalog.add("id", string="Hey {0} {1}!")
         with self.assertRaises(AttributeError):
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters=("you", "there")
+                "id", arguments=("you", "there")
             )
 
     # Tests that passing a list as a value for a parameter will raise an exception
@@ -180,7 +180,7 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         catalog.add("id", string="Hey {0} {1}!")
         with self.assertRaises(InvalidArgsError):
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters={"0": ["you ", "there"]}
+                "id", arguments={"0": ["you ", "there"]}
             )
 
     # Tests that badly formatted parameter in a catalog raises `ICUError`
@@ -189,7 +189,7 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         catalog.add("id", string="Hey {a b}!")
         with self.assertRaises(ICUError):
             result = MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters={"a": "you", "b": "!"}
+                "id", arguments={"a": "you", "b": "!"}
             )
 
     # Tests that a message in catalogs can use a numeric variable
@@ -198,18 +198,18 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         catalog.add("id", string="Hey {a} {0} {b}")
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters={"a": "you", "b": "!", "0": "there"}
+                "id", arguments={"a": "you", "b": "!", "0": "there"}
             ),
             "Hey you there !",
         )
 
     # Tests that a message in the catalogs can't break our system by having more or missing variables relative to the default
-    def test_message_different_parameters(self):
+    def test_message_different_arguments(self):
         catalog = Catalog()
         catalog.add("id", string="Hey {a} {0} {c}")
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters={"a": "you", "b": "!"}
+                "id", arguments={"a": "you", "b": "!"}
             ),
             "Hey you {0} {c}",
         )
@@ -225,7 +225,7 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
                 "id",
-                parameters={"a": "you"},
+                arguments={"a": "you"},
                 tags={
                     "a0": {
                         "tag": "a",
@@ -249,7 +249,7 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
                 "id",
-                parameters={"a": "you"},
+                arguments={"a": "you"},
                 tags={
                     "a0": {"tag": "a", "attrs": {"href": "/you"}},
                     "b0": {"tag": "b", "attrs": {"id": "hi"}},
@@ -258,14 +258,14 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
             '<a href="/you">Helloyouthere</a>',
         )
 
-    # Tests that parameters are substituted within tags
+    # Tests that arguments are substituted within tags
     def test_params_in_tags(self):
         catalog = Catalog()
         catalog.add("id", string="<a0>Hello {name}</a0>{test}")
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
                 "id",
-                parameters={"name": "you", "test": "!"},
+                arguments={"name": "you", "test": "!"},
                 tags={"a0": {"tag": "a", "attrs": {"href": "/you"}}},
             ),
             '<a href="/you">Hello you</a>!',
@@ -282,14 +282,14 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
             '<a href="/you">Hello &amp;&amp;</a>&gt;',
         )
 
-    # Tests that message parameters are escaped
+    # Tests that message arguments are escaped
     def test_escapes_params(self):
         catalog = Catalog()
         catalog.add("id", string="<a0>Hey {name}</a0>{test}")
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
                 "id",
-                parameters={"name": "<b>you</b>", "test": "<b>there</b>"},
+                arguments={"name": "<b>you</b>", "test": "<b>there</b>"},
                 tags={"a0": {"tag": "a", "attrs": {"href": "/you"}}},
             ),
             '<a href="/you">Hey &lt;b&gt;you&lt;/b&gt;</a>&lt;b&gt;there&lt;/b&gt;',
@@ -306,7 +306,7 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
             '<a href="/you?a=b&amp;c=d">Hey</a>',
         )
 
-    # Tests the combination of properties of placeholder tags and of message parameters.
+    # Tests the combination of properties of placeholder tags and of message arguments.
     # 0) In settings where there are multiple tags, some of which have to be deleted, all of them are processed
     # 1) the `tags` argument is used to replace placeholders and they are escaped correctly
     # 2) Tags or tag placeholders that have no counterpart in the arguments are removed
@@ -323,7 +323,7 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
                 "id",
-                parameters={"a": "you", "first": "hello", "second": "&"},
+                arguments={"a": "you", "first": "hello", "second": "&"},
                 tags={
                     "a0": {"tag": "a", "attrs": {"href": "/you"}},
                     "a1": {
@@ -357,19 +357,19 @@ class MessageTranslatorFormatHtmlTest(SimpleTestCase):
         )
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters={"a": "there", "g": "male", "n": 17}
+                "id", arguments={"a": "there", "g": "male", "n": 17}
             ),
             "Hello there, you have 17 boys",
         )
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters={"a": "there", "g": "female", "n": 18}
+                "id", arguments={"a": "there", "g": "female", "n": 18}
             ),
             "Hello there, you have 18 girls",
         )
         self.assertEqual(
             MessageTranslator("en", catalog).get_and_format_html_message(
-                "id", parameters={"a": "there", "g": "other", "n": 0}
+                "id", arguments={"a": "there", "g": "other", "n": 0}
             ),
             "Hello there, you have no children",
         )
@@ -418,7 +418,7 @@ class LocalizeTest(SimpleTestCase):
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
             with self.assertLogs(level=logging.ERROR):
-                result = localize("el", "id", parameters={"a": "you", "b": "!"})
+                result = localize("el", "id", arguments={"a": "you", "b": "!"})
             self.assertEqual(result, "Hello you !")
 
     # Tests that badly formatted parameter in the default catalog will break our system
@@ -431,7 +431,7 @@ class LocalizeTest(SimpleTestCase):
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
             with self.assertRaises(ICUError):
-                localize("el", "id", parameters={"a": "you", "b": "!"})
+                localize("el", "id", arguments={"a": "you", "b": "!"})
 
     def test_message_invalid_parameter_syntax_in_both(self):
         def mock_get_translations(locale):
@@ -445,7 +445,7 @@ class LocalizeTest(SimpleTestCase):
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
             with self.assertLogs(level=logging.ERROR):
                 with self.assertRaises(ICUError):
-                    localize("el", "id", parameters={"a": "you", "b": "!"})
+                    localize("el", "id", arguments={"a": "you", "b": "!"})
 
 
 class LocalizeHtmlTest(SimpleTestCase):
@@ -491,7 +491,7 @@ class LocalizeHtmlTest(SimpleTestCase):
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
             with self.assertLogs(level=logging.ERROR):
-                result = localize_html("el", "id", parameters={"a": "you", "b": "!"})
+                result = localize_html("el", "id", arguments={"a": "you", "b": "!"})
             self.assertEqual(result, "Hello you !")
 
     # Tests that badly formatted parameter in the default catalog will break our system
@@ -504,7 +504,7 @@ class LocalizeHtmlTest(SimpleTestCase):
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
             with self.assertRaises(ICUError):
-                localize_html("el", "id", parameters={"a": "you", "b": "!"})
+                localize_html("el", "id", arguments={"a": "you", "b": "!"})
 
     def test_message_invalid_parameter_syntax_in_both(self):
         def mock_get_translations(locale):
@@ -518,4 +518,4 @@ class LocalizeHtmlTest(SimpleTestCase):
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
             with self.assertLogs(level=logging.ERROR):
                 with self.assertRaises(ICUError):
-                    localize_html("el", "id", parameters={"a": "you", "b": "!"})
+                    localize_html("el", "id", arguments={"a": "you", "b": "!"})

--- a/docker-compose.commands.yml
+++ b/docker-compose.commands.yml
@@ -42,6 +42,7 @@ services:
       - virtualenvs:/root/.local/share/virtualenvs/:rw
     security_opt:
       - seccomp=docker/pyspawner-seccomp-profile.json
+    privileged: true
     cap_add: [ SYS_ADMIN ] # for cjwkernel.kernel to overlay-mount chroots (on k8s we use an init container instead)
     environment:
       <<: *django-env
@@ -61,6 +62,7 @@ services:
       - virtualenvs:/root/.local/share/virtualenvs/:rw
     security_opt:
       - seccomp=docker/pyspawner-seccomp-profile.json
+    privileged: true
     cap_add:
       - SYS_ADMIN # for cjwkernel.kernel to overlay-mount chroots (on k8s we use an init container instead)
       - NET_ADMIN # for pyspawner to create new network namespace without access to private network
@@ -82,6 +84,7 @@ services:
       - virtualenvs:/root/.local/share/virtualenvs/:rw
     security_opt:
       - seccomp=docker/pyspawner-seccomp-profile.json
+    privileged: true
     cap_add:
       - SYS_ADMIN # for cjwkernel.kernel to overlay-mount chroots (on k8s we use an init container instead)
       - NET_ADMIN # for pyspawner to create new network namespace without access to private network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       - virtualenvs:/root/.local/share/virtualenvs/:rw
     security_opt:
       - seccomp=docker/pyspawner-seccomp-profile.json
+    privileged: true
     cap_add: [ SYS_ADMIN ] # for setup-sandboxes.sh to overlay-mount chroots (on k8s we use an init container instead)
     environment: &django-env
       PYTHONUNBUFFERED: '1'
@@ -107,6 +108,7 @@ services:
       - virtualenvs:/root/.local/share/virtualenvs/:rw
     security_opt:
       - seccomp=docker/pyspawner-seccomp-profile.json
+    privileged: true
     cap_add:
       - SYS_ADMIN # for setup-sandboxes.sh to overlay-mount chroots (on k8s we use an init container instead)
       - NET_ADMIN # for pyspawner to create new network namespace without access to private network
@@ -136,6 +138,7 @@ services:
       - virtualenvs:/root/.local/share/virtualenvs/:rw
     security_opt:
       - seccomp=docker/pyspawner-seccomp-profile.json
+    privileged: true
     cap_add:
       - SYS_ADMIN # for setup-sandboxes.sh to overlay-mount chroots (on k8s we use an init container instead)
       - NET_ADMIN # for pyspawner to create new network namespace without access to private network

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,6 +3492,16 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -3911,6 +3921,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -5939,6 +5950,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -6177,6 +6195,564 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1",
+        "node-pre-gyp": "*"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minipass": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^3.2.6",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.14.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4.4.2"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.13",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.12",
@@ -7306,6 +7882,7 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",

--- a/renderer/execute/types.py
+++ b/renderer/execute/types.py
@@ -146,7 +146,7 @@ class PromptingError(Exception):
                     default="{ columns, plural, offset:2"
                     " =1 {The column “{0}” must be converted to Text.}"
                     " =2 {The columns “{0}” and “{1}” must be converted to Text.}"
-                    " one {The columns “{0}”, “{1}” and “{2}” must be converted to Text.}"
+                    " =3 {The columns “{0}”, “{1}” and “{2}” must be converted to Text.}"
                     " other {The columns “{0}”, “{1}” and # others must be converted to Text.}}",
                     args=icu_args,
                 )
@@ -159,7 +159,7 @@ class PromptingError(Exception):
                     default="{ columns, plural, offset:2"
                     " =1 {The column “{0}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}}.}"
                     " =2 {The columns “{0}” and “{1}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times}  other{}}.}"
-                    " one {The columns “{0}”, “{1}” and “{2}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.}"
+                    " =3 {The columns “{0}”, “{1}” and “{2}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.}"
                     " other {The columns “{0}”, “{1}” and # others must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.}}",
                     args=icu_args,
                 )

--- a/renderer/execute/types.py
+++ b/renderer/execute/types.py
@@ -5,9 +5,6 @@ from typing import FrozenSet, List, Optional
 from cjwkernel.types import I18nMessage, QuickFix, QuickFixAction, RenderError
 
 
-TypeNames = {"text": "Text", "number": "Numbers", "datetime": "Dates & Times"}
-
-
 class UnneededExecution(Exception):
     """A render would produce useless results."""
 
@@ -95,11 +92,21 @@ class PromptingError(Exception):
             
             Render errors will include a QuickFix that would resolve this error."""
             if self.should_be_text:
-                prompt = f"Convert to {self.best_wanted_type_name}"
-            else:
-                prompt = (
-                    f"Convert {self.found_type_name} to {self.best_wanted_type_name}"
+                message = I18nMessage.trans(
+                    "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.shouldBeText",
+                    default="Convert to Text.",
                 )
+            else:
+                # i18n: The parameters {found_type} and {best_wanted_type} will have values among "text", "number", "datetime"; however, including an (possibly empty) "other" case is mandatory.
+                message = I18nMessage.trans(
+                    "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.general",
+                    default="Convert { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.",
+                    args={
+                        "found_type": self.found_type,
+                        "best_wanted_type": self.best_wanted_type_id,
+                    },
+                )
+
             params = {"colnames": self.column_names}
 
             if "text" in self.wanted_types:
@@ -114,12 +121,7 @@ class PromptingError(Exception):
             return [
                 RenderError(
                     self._as_i18n_message(),
-                    [
-                        QuickFix(
-                            I18nMessage.TODO_i18n(prompt),
-                            QuickFixAction.PrependStep(module_id, params),
-                        )
-                    ],
+                    [QuickFix(message, QuickFixAction.PrependStep(module_id, params))],
                 )
             ]
 
@@ -128,31 +130,38 @@ class PromptingError(Exception):
             # TODO make each quick fix get its own paragraph. (For now, quick
             # fixes are nothing but buttons.)
 
-            names = [f"“{c}”" for c in self.column_names]
-            if len(names) > 3:
-                # "x", "y", "z", "a" => "x", "y", "2 others" (always more than
-                # 1 other -- if there were 1 other, we might as well have
-                # written the name itself)
-                names[2:] = [f"{len(names) - 2} others"]
-            if len(names) == 1:
-                columns_str = f"The column {names[0]}"
-            else:
-                # English-style:
-                # 2: "A" and "B"
-                # 3: "A", "B" and "C"
-                # 4+: "A", "B" and 2 others
-                names_str = ", ".join(names[:-1]) + " and " + names[-1]
-                columns_str = f"The columns {names_str}"
+            icu_args = {
+                "columns": len(self.column_names),
+                **{
+                    str(i): self.column_names[i]
+                    for i in range(0, len(self.column_names))
+                },
+            }
 
             if self.should_be_text:
                 # Convert to Text
-                return I18nMessage.TODO_i18n(
-                    f"{columns_str} must be converted to Text."
+                # i18n: The parameter {columns} will contain the total number of columns that need to be converted; you will also receive the column names as {0}, {1}, {2}, etc.
+                return I18nMessage.trans(
+                    "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.shouldBeText",
+                    default="{ columns, plural, offset:2"
+                    " =1 {The column “{0}” must be converted to Text.}"
+                    " =2 {The columns “{0}” and “{1}” must be converted to Text.}"
+                    " one {The columns “{0}”, “{1}” and “{2}” must be converted to Text.}"
+                    " other {The columns “{0}”, “{1}” and # others must be converted to Text.}}",
+                    args=icu_args,
                 )
             else:
-                return I18nMessage.TODO_i18n(
-                    f"{columns_str} must be converted "
-                    f"from {self.found_type_name} to {self.best_wanted_type_name}."
+                icu_args["found_type"] = self.found_type
+                icu_args["best_wanted_type"] = self.best_wanted_type_id
+                # i18n: The parameter {columns} will contain the total number of columns that need to be converted; you will also receive the column names: {0}, {1}, {2}, etc. The parameters {found_type} and {best_wanted_type} will have values among "text", "number", "datetime"; however, including a (possibly empty) "other" case is mandatory.
+                return I18nMessage.trans(
+                    "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.general",
+                    default="{ columns, plural, offset:2"
+                    " =1 {The column “{0}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}}.}"
+                    " =2 {The columns “{0}” and “{1}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times}  other{}}.}"
+                    " one {The columns “{0}”, “{1}” and “{2}” must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.}"
+                    " other {The columns “{0}”, “{1}” and # others must be converted from { found_type, select, text {Text} number {Numbers} datetime {Dates & Times} other {}} to {best_wanted_type, select, text {Text} number {Numbers} datetime {Dates & Times} other{}}.}}",
+                    args=icu_args,
                 )
 
     def __init__(self, errors: List[PromptingError.WrongColumnType]):

--- a/renderer/tests/execute/test_types.py
+++ b/renderer/tests/execute/test_types.py
@@ -18,12 +18,21 @@ class PromptingErrorTest(unittest.TestCase):
             result,
             [
                 RenderError(
-                    I18nMessage.TODO_i18n(
-                        "The column “A” must be converted from Text to Numbers."
+                    I18nMessage(
+                        "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.general",
+                        {
+                            "columns": 1,
+                            "0": "A",
+                            "found_type": "text",
+                            "best_wanted_type": "number",
+                        },
                     ),
                     [
                         QuickFix(
-                            I18nMessage.TODO_i18n("Convert Text to Numbers"),
+                            I18nMessage(
+                                "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.general",
+                                {"found_type": "text", "best_wanted_type": "number"},
+                            ),
                             QuickFixAction.PrependStep(
                                 "converttexttonumber", {"colnames": ["A"]}
                             ),
@@ -31,12 +40,25 @@ class PromptingErrorTest(unittest.TestCase):
                     ],
                 ),
                 RenderError(
-                    I18nMessage.TODO_i18n(
-                        "The columns “B” and “C” must be converted from Dates & Times to Numbers."
+                    I18nMessage(
+                        "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.general",
+                        {
+                            "columns": 2,
+                            "0": "B",
+                            "1": "C",
+                            "found_type": "datetime",
+                            "best_wanted_type": "number",
+                        },
                     ),
                     [
                         QuickFix(
-                            I18nMessage.TODO_i18n("Convert Dates & Times to Numbers"),
+                            I18nMessage(
+                                "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.general",
+                                {
+                                    "found_type": "datetime",
+                                    "best_wanted_type": "number",
+                                },
+                            ),
                             QuickFixAction.PrependStep(
                                 "converttexttonumber", {"colnames": ["B", "C"]}
                             ),
@@ -55,12 +77,15 @@ class PromptingErrorTest(unittest.TestCase):
             result,
             [
                 RenderError(
-                    I18nMessage.TODO_i18n(
-                        "The columns “A” and “B” must be converted to Text."
+                    I18nMessage(
+                        "py.renderer.execute.types.PromptingError.WrongColumnType.as_error_message.shouldBeText",
+                        {"columns": 2, "0": "A", "1": "B"},
                     ),
                     [
                         QuickFix(
-                            I18nMessage.TODO_i18n("Convert to Text"),
+                            I18nMessage(
+                                "py.renderer.execute.types.PromptingError.WrongColumnType.as_quick_fixes.shouldBeText"
+                            ),
                             QuickFixAction.PrependStep(
                                 "converttotext", {"colnames": ["A", "B"]}
                             ),

--- a/server/serializers.py
+++ b/server/serializers.py
@@ -266,7 +266,13 @@ def jsonize_clientside_tab(tab: clientside.TabUpdate) -> Dict[str, Any]:
     return d
 
 
-def jsonize_i18n_message(message: I18nMessage, ctx: JsonizeContext) -> Optional[str]:
+def jsonize_i18n_message(message: I18nMessage, ctx: JsonizeContext) -> str:
+    """Localize (or unwrap, if it's a TODO_i18n) an `I18nMessage`
+    
+    Uses `locale_id` from `ctx`
+    
+    Raises `KeyError` if the message text cannot be found in the catalogs.
+    """
     assert message.source is None
     if message.id == "TODO_i18n":
         return message.args["text"]

--- a/server/serializers.py
+++ b/server/serializers.py
@@ -266,23 +266,13 @@ def jsonize_clientside_tab(tab: clientside.TabUpdate) -> Dict[str, Any]:
     return d
 
 
-def jsonize_i18n_message(message: I18nMessage, ctx: JsonizeContext) -> str:
+def jsonize_i18n_message(message: I18nMessage, ctx: JsonizeContext) -> Optional[str]:
     assert message.source is None
     if message.id == "TODO_i18n":
         return message.args["text"]
     else:
         # Attempt to localize in the locale given by `ctx`.
-        #
-        # There may be no message in that locale for the id we are searching,
-        # in which case the `default` we pass (i.e. `None`) will be returned
-        # and we will ask for the message to be localized in the default locale.
-        # If there is no message for the default locale either,
-        # we opt to return the message id.
-        return localize(
-            ctx.locale_id, message.id, default=None, parameters=message.args
-        ) or localize(
-            default_locale, message.id, default=message.id, parameters=message.args
-        )
+        return localize(ctx.locale_id, message.id, parameters=message.args)
 
 
 def jsonize_quick_fix(quick_fix: QuickFix, ctx: JsonizeContext) -> Dict[str, Any]:

--- a/server/serializers.py
+++ b/server/serializers.py
@@ -271,6 +271,13 @@ def jsonize_i18n_message(message: I18nMessage, ctx: JsonizeContext) -> str:
     if message.id == "TODO_i18n":
         return message.args["text"]
     else:
+        # Attempt to localize in the locale given by `ctx`.
+        #
+        # There may be no message in that locale for the id we are searching,
+        # in which case the `default` we pass (i.e. `None`) will be returned
+        # and we will ask for the message to be localized in the default locale.
+        # If there is no message for the default locale either,
+        # we opt to return the message id.
         return localize(
             ctx.locale_id, message.id, default=None, parameters=message.args
         ) or localize(

--- a/server/serializers.py
+++ b/server/serializers.py
@@ -281,7 +281,7 @@ def jsonize_i18n_message(message: I18nMessage, ctx: JsonizeContext) -> str:
     else:
         # Attempt to localize in the locale given by `ctx`.
         try:
-            return localize(ctx.locale_id, message.id, parameters=message.args)
+            return localize(ctx.locale_id, message.id, arguments=message.args)
         except ICUError as err:
             # `localize` handles `ICUError` for the given locale.
             # Hence, if we get here, it means that the message is badly formatted in the default locale.

--- a/server/serializers.py
+++ b/server/serializers.py
@@ -15,6 +15,8 @@ from server.settingsutils import workbench_user_display
 from cjwstate.models.param_spec import ParamSpec
 from cjwstate import clientside
 from cjwkernel.types import RenderError
+from cjworkbench.i18n import default_locale
+from cjworkbench.i18n.trans import localize
 
 User = get_user_model()
 
@@ -265,10 +267,15 @@ def jsonize_clientside_tab(tab: clientside.TabUpdate) -> Dict[str, Any]:
 
 
 def jsonize_i18n_message(message: I18nMessage, ctx: JsonizeContext) -> str:
+    assert message.source is None
     if message.id == "TODO_i18n":
         return message.args["text"]
     else:
-        raise RuntimeError("TODO_i18n")
+        return localize(
+            ctx.locale_id, message.id, default=None, parameters=message.args
+        ) or localize(
+            default_locale, message.id, default=message.id, parameters=message.args
+        )
 
 
 def jsonize_quick_fix(quick_fix: QuickFix, ctx: JsonizeContext) -> Dict[str, Any]:

--- a/server/templatetags/i18n_icu.py
+++ b/server/templatetags/i18n_icu.py
@@ -124,6 +124,6 @@ def trans_html(
         locale_id = default_locale
 
     result = localize_html(
-        locale_id, message_id, context=ctxt or None, tags=tags, parameters=params
+        locale_id, message_id, context=ctxt or None, tags=tags, arguments=params
     )
     return mark_safe(result)

--- a/server/templatetags/i18n_icu.py
+++ b/server/templatetags/i18n_icu.py
@@ -126,4 +126,4 @@ def trans_html(
     result = localize_html(
         locale_id, message_id, context=ctxt or None, tags=tags, parameters=params
     )
-    return mark_safe(result) if result else None
+    return mark_safe(result)

--- a/server/tests/templatetags/test_i18n_icu.py
+++ b/server/tests/templatetags/test_i18n_icu.py
@@ -1,69 +1,103 @@
 import logging
 import re
 from django.test import SimpleTestCase
-from cjworkbench.i18n import default_locale
 from server.templatetags.i18n_icu import trans_html
-
-
-mock_message_id = (
-    "some+crazy+id+that+will+never+be+actually+used+in+real+translation+files"
-)
+from unittest.mock import patch
+from babel.messages.catalog import Catalog
+from cjworkbench.i18n.trans import MessageTranslator
+from django.template import Context, Template
 
 
 def mock_context(**kwargs):
-    return {"i18n": {"locale_id": kwargs.get("locale_id", default_locale)}}
+    return {"i18n": {"locale_id": kwargs.get("locale_id", "en")}}
 
 
 class TransTemplateTagTests(SimpleTestCase):
     # Tests that `noop=True` returns `None`
     def test_trans_noop(self):
-        self.assertIsNone(
-            trans_html(
-                mock_context(), mock_message_id, noop=True, default="Hello {a} {b}!"
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            catalog.add("id", string="Hello {a} {b}!")
+            return MessageTranslator(locale, catalog)
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertIsNone(
+                trans_html(mock_context(), "id", noop=True, default="Hello {a} {b}!")
             )
-        )
+
+    # Tests that the default argument is ignored
+    def test_default_is_ignored(self):
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            catalog.add("id", string="Hello")
+            return MessageTranslator(locale, catalog)
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertEqual(
+                trans_html(mock_context(), "id", default="Nothing"), "Hello"
+            )
 
     # Tests that `arg_XX` arguments replace variables in the message.
-    # 1) Parameters that do not exist in the message are ignored.
-    # 2) Variables in the message for which no parameter has been given are ignored.
-    # 3) The order of `arg` arguments is not important.
-    # 4) When the programmer tries to use numeric arguments, an exception is raised (behaviour for when the translator tries to use numeric arguments is tested elsewhere)
+    # The order of `arg` arguments is not important.
+    # Numeric arguments work correctly
     def test_trans_params(self):
-        self.assertEqual(
-            trans_html(
-                mock_context(),
-                mock_message_id,
-                default="Hello {a} {param_b} {c}!",
-                arg_param_b="there",
-                arg_a="you",
-                arg_d="tester",
-            ),
-            "Hello you there {c}!",
-        )
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            catalog.add("id", string="Hello {a} {0} {b}")
+            return MessageTranslator(locale, catalog)
 
-        self.assertEqual(
-            trans_html(
-                mock_context(),
-                mock_message_id,
-                default="Hello {a} {0} {b}",
-                arg_a="you",
-                arg_0="!",
-                arg_b="2",
-            ),
-            "Hello you ! 2",
-        )
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertEqual(
+                trans_html(
+                    mock_context(),
+                    "id",
+                    default="Hello {a} {0} {b}",
+                    arg_b="2",
+                    arg_a="you",
+                    arg_0="!",
+                ),
+                "Hello you ! 2",
+            )
 
+    # Tests that tags without attributes are supported
     def test_trans_tag_without_attributes(self):
-        self.assertEqual(
-            trans_html(
-                mock_context(),
-                mock_message_id,
-                default="Hello <b0>{param_b}</b0>!",
-                arg_param_b="there",
-                tag_b0="",
-            ),
-            "Hello <b>there</b>!",
-        )
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            catalog.add("id", string="Hello <b0>{param_b}</b0>!")
+            return MessageTranslator(locale, catalog)
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertEqual(
+                trans_html(
+                    mock_context(),
+                    "id",
+                    default="Hello <b0>{param_b}</b0>!",
+                    arg_param_b="there",
+                    tag_b0="",
+                ),
+                "Hello <b>there</b>!",
+            )
+
+    # Tests that when a message does not exist in the context locale, it is returned in the default locale
+    def test_default_locale(self):
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            if locale == "en":
+                catalog.add("id", "Hello")
+            return MessageTranslator(locale, catalog)
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertEqual(
+                trans_html(mock_context(locale_id="el"), "id", default="Hello"), "Hello"
+            )
+
+    # Tests that when a message does not exist in the catalogs, `None` is returned
+    def test_missing_message(self):
+        def mock_get_translations(locale):
+            return MessageTranslator(locale, Catalog())
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertIsNone(trans_html(mock_context(), "id", default="Hello"))
 
     # Tests the combination of properties of placeholder tags and of message parameters.
     # 0) In settings where there are multiple tags, some of which have to be deleted, all of them are processed
@@ -75,23 +109,32 @@ class TransTemplateTagTests(SimpleTestCase):
     # 6) Nested tags are not tolerated
     # 7) `arg_XX` arguments are replaced correctly
     def test_trans_tag_placeholders(self):
-        self.assertEqual(
-            trans_html(
-                mock_context(),
-                mock_message_id,
-                default='<em0>Hello</em0> <span0 class="nope">{first}</span0><span1></span1> {second} <a0>{a}<b></b></a0> < <a1>there<</a1>!<br /><script type="text/javascript" src="mybadscript.js"></script>',
-                arg_a="you",
-                tag_a0_href="/you",
-                tag_a1_href="/there?a=b&c=d",
-                tag_a1_class="red big",
-                tag_span0_id="hi",
-                tag_em0="",
-                tag_div0_class="red big",
-                arg_first="hello",
-                arg_second="&",
-            ),
-            '<em>Hello</em> <span id="hi">hello</span> &amp; <a href="/you">you</a> &lt; <a class="red big" href="/there?a=b&amp;c=d">there&lt;</a>!',
-        )
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            catalog.add(
+                "id",
+                string='<em0>Hello</em0> <span0 class="nope">{first}</span0><span1></span1> {second} <a0>{a}<b></b></a0> < <a1>there<</a1>!<br /><script type="text/javascript" src="mybadscript.js"></script>',
+            )
+            return MessageTranslator(locale, catalog)
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertEqual(
+                trans_html(
+                    mock_context(),
+                    "id",
+                    default='<em0>Hello</em0> <span0 class="nope">{first}</span0><span1></span1> {second} <a0>{a}<b></b></a0> < <a1>there<</a1>!<br /><script type="text/javascript" src="mybadscript.js"></script>',
+                    arg_a="you",
+                    tag_a0_href="/you",
+                    tag_a1_href="/there?a=b&c=d",
+                    tag_a1_class="red big",
+                    tag_span0_id="hi",
+                    tag_em0="",
+                    tag_div0_class="red big",
+                    arg_first="hello",
+                    arg_second="&",
+                ),
+                '<em>Hello</em> <span id="hi">hello</span> &amp; <a href="/you">you</a> &lt; <a class="red big" href="/there?a=b&amp;c=d">there&lt;</a>!',
+            )
 
     def test_trans_html_with_missing_context_i18n(self):
         # context[i18n] needs to be managed by the caller. And sometimes, the
@@ -100,18 +143,21 @@ class TransTemplateTagTests(SimpleTestCase):
         #
         # Calling trans_html without a context[i18n] is always a bug. So let's
         # test that it's logged.
-        with self.assertLogs(level=logging.ERROR) as cm:
-            result = trans_html(
-                {"invalid-context": "yup"}, mock_message_id, default="Show the message"
-            )
-        self.assertEqual(result, "Show the message")
-        self.assertRegex(
-            cm.output[0],
-            re.escape(
-                (
-                    "ERROR:server.templatetags.i18n_icu:"
-                    "Missing context['i18n']['locale_id'] translating message_id "
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            catalog.add("id", string="Show the message")
+            return MessageTranslator(locale, catalog)
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            with self.assertLogs(level=logging.ERROR) as cm:
+                result = trans_html(
+                    {"invalid-context": "yup"}, "id", default="Show the message"
                 )
-                + mock_message_id
-            ),
-        )
+            self.assertEqual(result, "Show the message")
+            self.assertRegex(
+                cm.output[0],
+                re.escape(
+                    "ERROR:server.templatetags.i18n_icu:"
+                    "Missing context['i18n']['locale_id'] translating message_id id"
+                ),
+            )

--- a/server/tests/templatetags/test_i18n_icu.py
+++ b/server/tests/templatetags/test_i18n_icu.py
@@ -97,7 +97,8 @@ class TransTemplateTagTests(SimpleTestCase):
             return MessageTranslator(locale, Catalog())
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
-            self.assertIsNone(trans_html(mock_context(), "id", default="Hello"))
+            with self.assertRaises(KeyError):
+                trans_html(mock_context(), "id", default="Hello")
 
     # Tests the combination of properties of placeholder tags and of message parameters.
     # 0) In settings where there are multiple tags, some of which have to be deleted, all of them are processed

--- a/server/tests/test_serializers.py
+++ b/server/tests/test_serializers.py
@@ -1,0 +1,67 @@
+import unittest
+from cjwkernel.types import I18nMessage, QuickFix, QuickFixAction, RenderError
+from server.serializers import jsonize_i18n_message, JsonizeContext
+from cjworkbench.i18n.trans import MessageTranslator
+from unittest.mock import patch
+from babel.messages.catalog import Catalog
+
+
+def mock_jsonize_context(user=None, session=None, locale_id=None):
+    return JsonizeContext(user=user, session=session, locale_id=locale_id)
+
+
+class JsonizeI18nMessageTest(unittest.TestCase):
+    def test_TODO_i18n(self):
+        self.assertEqual(
+            jsonize_i18n_message(
+                I18nMessage.TODO_i18n("hello"), mock_jsonize_context(locale_id="en")
+            ),
+            "hello",
+        )
+
+    def test_source_None_message_exists_in_given_locale(self):
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            if locale == "en":
+                catalog.add("id", string="Hello")
+                return MessageTranslator(locale, catalog)
+            else:
+                catalog.add("id", string="Hey")
+                return MessageTranslator(locale, catalog)
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertEqual(
+                jsonize_i18n_message(
+                    I18nMessage("id"), mock_jsonize_context(locale_id="el")
+                ),
+                "Hey",
+            )
+
+    def test_source_None_message_exists_only_in_default_locale(self):
+        def mock_get_translations(locale):
+            catalog = Catalog()
+            if locale == "en":
+                catalog.add("id", string="Hello")
+                return MessageTranslator(locale, catalog)
+            else:
+                return MessageTranslator(locale, catalog)
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertEqual(
+                jsonize_i18n_message(
+                    I18nMessage("id"), mock_jsonize_context(locale_id="el")
+                ),
+                "Hello",
+            )
+
+    def test_source_None_message_exists_in_no_locales(self):
+        def mock_get_translations(locale):
+            return MessageTranslator(locale, Catalog())
+
+        with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
+            self.assertEqual(
+                jsonize_i18n_message(
+                    I18nMessage("id"), mock_jsonize_context(locale_id="el")
+                ),
+                "id",
+            )

--- a/server/tests/test_serializers.py
+++ b/server/tests/test_serializers.py
@@ -56,8 +56,7 @@ class JsonizeI18nMessageTest(unittest.TestCase):
             return MessageTranslator(locale, Catalog())
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
-            self.assertIsNone(
+            with self.assertRaises(KeyError):
                 jsonize_i18n_message(
                     I18nMessage("id"), mock_jsonize_context(locale_id="el")
                 )
-            )

--- a/server/tests/test_serializers.py
+++ b/server/tests/test_serializers.py
@@ -24,10 +24,9 @@ class JsonizeI18nMessageTest(unittest.TestCase):
             catalog = Catalog()
             if locale == "en":
                 catalog.add("id", string="Hello")
-                return MessageTranslator(locale, catalog)
             else:
                 catalog.add("id", string="Hey")
-                return MessageTranslator(locale, catalog)
+            return MessageTranslator(locale, catalog)
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
             self.assertEqual(
@@ -42,9 +41,7 @@ class JsonizeI18nMessageTest(unittest.TestCase):
             catalog = Catalog()
             if locale == "en":
                 catalog.add("id", string="Hello")
-                return MessageTranslator(locale, catalog)
-            else:
-                return MessageTranslator(locale, catalog)
+            return MessageTranslator(locale, catalog)
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
             self.assertEqual(
@@ -59,9 +56,8 @@ class JsonizeI18nMessageTest(unittest.TestCase):
             return MessageTranslator(locale, Catalog())
 
         with patch("cjworkbench.i18n.trans._get_translations", mock_get_translations):
-            self.assertEqual(
+            self.assertIsNone(
                 jsonize_i18n_message(
                     I18nMessage("id"), mock_jsonize_context(locale_id="el")
-                ),
-                "id",
+                )
             )

--- a/server/websockets.py
+++ b/server/websockets.py
@@ -170,7 +170,9 @@ class WorkflowConsumer(AsyncJsonWebsocketConsumer):
 
     async def send_update(self, update: clientside.Update) -> None:
         logger.debug("Send update to Workflow %d", self.workflow_id)
-        ctx = JsonizeContext(self.scope["user"], self.scope["session"], "TODO_i18n")
+        ctx = JsonizeContext(
+            self.scope["user"], self.scope["session"], self.scope["locale_id"]
+        )
         json_dict = jsonize_clientside_update(update, ctx)
         await self.send_json({"type": "apply-delta", "data": json_dict})
 


### PR DESCRIPTION
This pull request replaces English `TODO_i18n` error texts in `renderer.execute.types` with ICU `I18nMessage`s. In order for them to be able to get localized, the pull request also makes use of recent changes in asgi middleware, serialization, and `I18nMessage`s.