### PR TITLE
Add module id to clientside.Update when the update contains I18nMessages

### DIFF
--- a/cjwstate/clientside.py
+++ b/cjwstate/clientside.py
@@ -163,7 +163,11 @@ class StepUpdate:
     """
     Module identifier.
 
-    Required for creation, and must be None afterwards.
+    Required for creation, and must usually be None afterwards.
+    
+    When a `render_result` is provided, you must also pass a `module_slug`.
+    This is so that `I18nMessage`s with source `"module"` in the result
+    can be interpreted relative to their source module.
     """
 
     tab_slug: Optional[str] = None

--- a/cjwstate/clientside.py
+++ b/cjwstate/clientside.py
@@ -163,11 +163,8 @@ class StepUpdate:
     """
     Module identifier.
 
-    Required for creation, and must usually be None afterwards.
-    
-    When a `render_result` is provided, you must also pass a `module_slug`.
-    This is so that `I18nMessage`s with source `"module"` in the result
-    can be interpreted relative to their source module.
+    Required for creation, and must usually be None afterwards,
+    except when `render_result` is not empty.
     """
 
     tab_slug: Optional[str] = None
@@ -200,6 +197,10 @@ class StepUpdate:
     If the cached-result delta ID is different from the _relevant_ delta ID,
     then the result is obsolete. The client may render obsolete data plus a
     progress indicator.
+    
+    When a `render_result` is provided, you must also pass a `module_slug`.
+    This is so that `I18nMessage`s with source `"module"` in the result
+    can be interpreted relative to their source module.
     """
 
     files: Optional[List[UploadedFile]] = None

--- a/renderer/execute/wf_module.py
+++ b/renderer/execute/wf_module.py
@@ -447,7 +447,14 @@ async def execute_wfmodule(
     crr, output_delta = await _execute_wfmodule_save(workflow, wf_module, result)
 
     update = clientside.Update(
-        steps={wf_module.id: clientside.StepUpdate(render_result=crr)}
+        steps={
+            wf_module.id: clientside.StepUpdate(
+                render_result=crr,
+                # We also add `module_slug`, in order for `I18nMessage`s with source `"module"`
+                # in `render_result` to be bound to their module
+                module_slug=wf_module.module_id_name,
+            )
+        }
     )
     await rabbitmq.send_update_to_workflow_clients(workflow.id, update)
 

--- a/renderer/tests/execute/test_workflow.py
+++ b/renderer/tests/execute/test_workflow.py
@@ -195,7 +195,7 @@ class WorkflowTests(DbTestCaseWithModuleRegistry):
             clientside.Update(
                 steps={
                     wf_module3.id: clientside.StepUpdate(
-                        render_result=wf_module3.cached_render_result
+                        render_result=wf_module3.cached_render_result, module_slug="mod"
                     )
                 }
             ),


### PR DESCRIPTION
Issue: with module id missing from `clientside.Update`, there is no way to tell in which module's catalogs to search, hence `server.serializers.jsonize_clientside_step` adds `None` as module id to the jsonize context which causes to `server.serializers._i18n_message_source_to_localizer` raise `KeyError`.