### PR TITLE
Remove links to retired server from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 
 Welcome to Workbench!
 
-- Our [public server](https://workbenchdata.com).
-
 Workbench is a platform that helps you make sense of data tables. Code like a pro -- without code.
 
 Features include:
@@ -28,9 +26,7 @@ Features include:
 
 # Try it
 
-To see what Workbench does, try our [public server](https://workbenchdata.com).
-
-Or run your [own server](https://github.com/CJWorkbench/cjworkbench/wiki/Deployment).
+To see what Workbench does, run your [own server](https://github.com/CJWorkbench/cjworkbench/wiki/Deployment).
 
 <div align="center">
   <img src="https://github.com/CJWorkbench/cjworkbench/blob/master/assets/images/demoSignup.gif"><br>


### PR DESCRIPTION
Per this [tweet](https://twitter.com/workbenchdata/status/1483597535486742529), the public server was shutdown a couple of years ago, so leaving a link to it in the README is a just an attractive nuisance. My browser plugins block loading the page, so I suspect it's either owner by domain squatters or some other nefarious types.
