### PR TITLE
fix(docker-compose): Remove duplicate staticfiles service entry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       context: .
       target: jsbase
     volumes:
-      # Migrate 
+      # Migrate
       - type: bind
         source: ./
         target: /app/
@@ -280,31 +280,6 @@ services:
       'sh',
       '-c',
       'cjwkernel/setup-sandboxes.sh only-readonly && /opt/venv/django/bin/python bin/watch-and-restart --exclude "**/*.pyc" "**/tests/**/*" --pattern "cjwstate/**/*.py" "cjworkbench/**/*.py" "tusdhooks/**/*.py" --exec bin/tusd-hooks-prod'
-    ]
-
-  staticfiles:
-    build:
-      context: .
-      target: pydev
-    volumes:
-      - type: bind
-        source: ./
-        target: /app/
-        consistency: cached
-    ports: [ '8003:8003' ]
-    networks: [ 'dev' ]
-    environment:
-      DJANGO_SETTINGS_MODULE: staticfilesdev.settings
-    command: [
-      '/opt/venv/django/bin/python',
-      '-m',
-      'uvicorn',
-      '--host',
-      '0.0.0.0',
-      '--port',
-      '8003',
-      '--use-colors',
-      'staticfilesdev.asgi:application'
     ]
 
   tusd:


### PR DESCRIPTION
## Motivation

Per the [wiki](https://github.com/CJWorkbench/cjworkbench/wiki/Setting-up-a-development-environment#developer-workflow), `bin/dev start`  was not launch as the docker-compose file was not parseable by the yaml library.

<img width="783" alt="image" src="https://github.com/user-attachments/assets/fae3845b-0ffc-48f3-9baa-fca64f5e536e">

## Changes

Removes duplicate section from `docker-compose.yml` (removed section matches)

https://github.com/CJWorkbench/cjworkbench/blob/0f7433139ba45d7c379d677f93aebb1c6c419168/docker-compose.yml#L128-L151

## Testing

I'm not able to get the app running locally for unrelated reasons (pandas, pybind11 , google-re2, numpy are not installing), but I'll work on debugging those separately. We won't be able to reach that step unless we clear the YAML installation step first. 
